### PR TITLE
Add timeout options

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,6 +20,12 @@
   revision = "0a4f71a498b7c4812f64969510bcb4eca251e33a"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/google/go-cmp"
+  packages = ["cmp","cmp/cmpopts"]
+  revision = "f299ad1c37e02b87f050c93c5d86af49a2850fc1"
+
+[[projects]]
   name = "github.com/google/gops"
   packages = ["agent","internal","signal"]
   revision = "fa6968806ca68b7db113256f300d82b5206a2c3c"
@@ -106,6 +112,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8db03b62d536e1f6ca45e3574f1d96d082b175a3c4a825e20a238e2cf3544722"
+  inputs-digest = "c5692d68794da26b447cc5fc7607832f93055187dc312625f579e3cb80a437a5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-gcs-helper
-==========
+# gcs-helper
 
 [![Build Status](https://travis-ci.org/NYTimes/gcs-helper.svg?branch=master)](https://travis-ci.org/NYTimes/gcs-helper)
 [![codecov](https://codecov.io/gh/NYTimes/gcs-helper/branch/master/graph/badge.svg)](https://codecov.io/gh/NYTimes/gcs-helper)
@@ -15,8 +14,7 @@ It also provides the needed support for the mapped mode (when using the proper
 environment variables - ``GCS_HELPER_PROXY_PREFIX``, ``GCS_HELPER_MAP_PREFIX``
 and ``GCS_HELPER_MAP_EXTENSIONS``).
 
-Configuration
--------------
+## Configuration
 
 The following environment variables control the behavior of gcs-helper:
 
@@ -26,6 +24,25 @@ The following environment variables control the behavior of gcs-helper:
 | GCS_HELPER_BUCKET_NAME    |               | Yes      | Name of the bucket                                                                                           |
 | GCS_HELPER_LOG_LEVEL      | debug         | No       | Logging level                                                                                                |
 | GCS_HELPER_PROXY_PREFIX   |               | No       | Prefix to use for the proxy binding. Required if running in map and proxy modes (example value: ``/proxy/``) |
-| GCS_HELPER_PROXY_TIMEOUT  | 2s            | No       | Defines the maximum time in serving the proxy requests                                                       |
+| GCS_HELPER_PROXY_TIMEOUT  | 10s           | No       | Defines the maximum time in serving the proxy requests, this is a hard timeout and includes retries          |
 | GCS_HELPER_MAP_PREFIX     |               | No       | Prefix to use for the map binding. Required if running in map and proxy modes (example value: ``/map/``)     |
 | GCS_HELPER_MAP_EXTENSIONS |               | No       | Comma separated list of extensions to include in the mapping (example value: ``.mp4,.vtt,.srt``)             |
+
+The are also some configuration variables for network communication with Google
+Cloud Storage API:
+
+| Variable                     | Default value | Required | Description                                                                                                  |
+| ---------------------------- | ------------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| GCS_CLIENT_TIMEOUT           | 2s            | No       | Hard timeout on requests that gcs-helper sends to the Google Storage API                                     |
+| GCS_CLIENT_IDLE_CONN_TIMEOUT | 120s          | No       | Maximum duration of idle connections between gcs-helper and the Google Storage API                           |
+| GCS_CLIENT_MAX_IDLE_CONNS    | 10            | No       | Maximum number of idle connections to keep open. This doesn't control the maximum number of connections      |
+
+### GCS_HELPER_PROXY_TIMEOUT x GCS_CLIENT_TIMEOUT
+
+The timeout configuration is mainly controlled by two environment variables:
+``GCS_HELPER_PROXY_TIMEOUT`` and ``GCS_CLIENT_TIMEOUT``. The
+``GCS_HELPER_PROXY_TIMEOUT`` controls how long requests to gcs-helper can take,
+and ``GCS_CLIENT_TIMEOUT`` controls how long requests from gcs-helper to
+Google's API can take. Since gcs-helper automatically retries on failures, the
+number of retries is roughly the value of ``GCS_HELPER_PROXY_TIMEOUT`` divided
+by the value of ``GCS_CLIENT_TIMEOUT``.

--- a/README.md
+++ b/README.md
@@ -26,5 +26,6 @@ The following environment variables control the behavior of gcs-helper:
 | GCS_HELPER_BUCKET_NAME    |               | Yes      | Name of the bucket                                                                                           |
 | GCS_HELPER_LOG_LEVEL      | debug         | No       | Logging level                                                                                                |
 | GCS_HELPER_PROXY_PREFIX   |               | No       | Prefix to use for the proxy binding. Required if running in map and proxy modes (example value: ``/proxy/``) |
+| GCS_HELPER_PROXY_TIMEOUT  | 2s            | No       | Defines the maximum time in serving the proxy requests                                                       |
 | GCS_HELPER_MAP_PREFIX     |               | No       | Prefix to use for the map binding. Required if running in map and proxy modes (example value: ``/map/``)     |
 | GCS_HELPER_MAP_EXTENSIONS |               | No       | Comma separated list of extensions to include in the mapping (example value: ``.mp4,.vtt,.srt``)             |

--- a/config.go
+++ b/config.go
@@ -16,9 +16,19 @@ type Config struct {
 	LogLevel        string        `envconfig:"LOG_LEVEL" default:"debug"`
 	ProxyLogHeaders []string      `envconfig:"PROXY_LOG_HEADERS"`
 	ProxyPrefix     string        `envconfig:"PROXY_PREFIX"`
-	ProxyTimeout    time.Duration `envconfig:"PROXY_TIMEOUT" default:"2s"`
+	ProxyTimeout    time.Duration `envconfig:"PROXY_TIMEOUT" default:"10s"`
 	MapPrefix       string        `envconfig:"MAP_PREFIX"`
 	MapExtensions   []string      `envconfig:"MAP_EXTENSIONS"`
+	ClientConfig    ClientConfig
+}
+
+// ClientConfig contains configuration for the GCS client communication.
+//
+// It contains options related to timeouts and keep-alive connections.
+type ClientConfig struct {
+	Timeout         time.Duration `envconfig:"GCS_CLIENT_TIMEOUT" default:"2s"`
+	IdleConnTimeout time.Duration `envconfig:"GCS_CLIENT_IDLE_CONN_TIMEOUT" default:"120s"`
+	MaxIdleConns    int           `envconfig:"GCS_CLIENT_MAX_IDLE_CONNS" default:"10"`
 }
 
 func (c Config) checkExtension(ext string) bool {

--- a/config.go
+++ b/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 	"github.com/sirupsen/logrus"
@@ -10,13 +11,14 @@ import (
 // Config represents the gcs-helper configuration that is loaded from the
 // environment.
 type Config struct {
-	Listen          string   `default:":8080"`
-	BucketName      string   `envconfig:"BUCKET_NAME" required:"true"`
-	LogLevel        string   `envconfig:"LOG_LEVEL" default:"debug"`
-	ProxyLogHeaders []string `envconfig:"PROXY_LOG_HEADERS"`
-	ProxyPrefix     string   `envconfig:"PROXY_PREFIX"`
-	MapPrefix       string   `envconfig:"MAP_PREFIX"`
-	MapExtensions   []string `envconfig:"MAP_EXTENSIONS"`
+	Listen          string        `default:":8080"`
+	BucketName      string        `envconfig:"BUCKET_NAME" required:"true"`
+	LogLevel        string        `envconfig:"LOG_LEVEL" default:"debug"`
+	ProxyLogHeaders []string      `envconfig:"PROXY_LOG_HEADERS"`
+	ProxyPrefix     string        `envconfig:"PROXY_PREFIX"`
+	ProxyTimeout    time.Duration `envconfig:"PROXY_TIMEOUT" default:"2s"`
+	MapPrefix       string        `envconfig:"MAP_PREFIX"`
+	MapExtensions   []string      `envconfig:"MAP_EXTENSIONS"`
 }
 
 func (c Config) checkExtension(ext string) bool {

--- a/config_test.go
+++ b/config_test.go
@@ -17,8 +17,11 @@ func TestLoadConfig(t *testing.T) {
 		"GCS_HELPER_MAP_PREFIX":        "/map/",
 		"GCS_HELPER_PROXY_PREFIX":      "/proxy/",
 		"GCS_HELPER_PROXY_LOG_HEADERS": "Accept,Range",
-		"GCS_HELPER_PROXY_TIMEOUT":     "1s",
+		"GCS_HELPER_PROXY_TIMEOUT":     "20s",
 		"GCS_HELPER_MAP_EXTENSIONS":    ".mp4,.vtt,.srt",
+		"GCS_CLIENT_TIMEOUT":           "60s",
+		"GCS_CLIENT_IDLE_CONN_TIMEOUT": "3m",
+		"GCS_CLIENT_MAX_IDLE_CONNS":    "16",
 	})
 	config, err := loadConfig()
 	if err != nil {
@@ -32,7 +35,12 @@ func TestLoadConfig(t *testing.T) {
 		ProxyPrefix:     "/proxy/",
 		MapExtensions:   []string{".mp4", ".vtt", ".srt"},
 		ProxyLogHeaders: []string{"Accept", "Range"},
-		ProxyTimeout:    time.Second,
+		ProxyTimeout:    20 * time.Second,
+		ClientConfig: ClientConfig{
+			IdleConnTimeout: 3 * time.Minute,
+			MaxIdleConns:    16,
+			Timeout:         time.Minute,
+		},
 	}
 	if !reflect.DeepEqual(config, expectedConfig) {
 		t.Errorf("wrong config returned\nwant %#v\ngot  %#v", expectedConfig, config)
@@ -49,7 +57,12 @@ func TestLoadConfigDefaultValues(t *testing.T) {
 		BucketName:   "some-bucket",
 		Listen:       ":8080",
 		LogLevel:     "debug",
-		ProxyTimeout: 2 * time.Second,
+		ProxyTimeout: 10 * time.Second,
+		ClientConfig: ClientConfig{
+			IdleConnTimeout: 120 * time.Second,
+			MaxIdleConns:    10,
+			Timeout:         2 * time.Second,
+		},
 	}
 	if !reflect.DeepEqual(config, expectedConfig) {
 		t.Errorf("wrong config returned\nwant %#v\ngot  %#v", expectedConfig, config)

--- a/config_test.go
+++ b/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -16,6 +17,7 @@ func TestLoadConfig(t *testing.T) {
 		"GCS_HELPER_MAP_PREFIX":        "/map/",
 		"GCS_HELPER_PROXY_PREFIX":      "/proxy/",
 		"GCS_HELPER_PROXY_LOG_HEADERS": "Accept,Range",
+		"GCS_HELPER_PROXY_TIMEOUT":     "1s",
 		"GCS_HELPER_MAP_EXTENSIONS":    ".mp4,.vtt,.srt",
 	})
 	config, err := loadConfig()
@@ -30,6 +32,7 @@ func TestLoadConfig(t *testing.T) {
 		ProxyPrefix:     "/proxy/",
 		MapExtensions:   []string{".mp4", ".vtt", ".srt"},
 		ProxyLogHeaders: []string{"Accept", "Range"},
+		ProxyTimeout:    time.Second,
 	}
 	if !reflect.DeepEqual(config, expectedConfig) {
 		t.Errorf("wrong config returned\nwant %#v\ngot  %#v", expectedConfig, config)
@@ -43,9 +46,10 @@ func TestLoadConfigDefaultValues(t *testing.T) {
 		t.Fatal(err)
 	}
 	expectedConfig := Config{
-		BucketName: "some-bucket",
-		Listen:     ":8080",
-		LogLevel:   "debug",
+		BucketName:   "some-bucket",
+		Listen:       ":8080",
+		LogLevel:     "debug",
+		ProxyTimeout: 2 * time.Second,
 	}
 	if !reflect.DeepEqual(config, expectedConfig) {
 		t.Errorf("wrong config returned\nwant %#v\ngot  %#v", expectedConfig, config)

--- a/main.go
+++ b/main.go
@@ -28,14 +28,7 @@ func main() {
 		log.Fatal(err)
 	}
 	logger := config.logger()
-	hc := http.Client{
-		Timeout: config.ClientConfig.Timeout,
-		Transport: &http.Transport{
-			IdleConnTimeout: config.ClientConfig.IdleConnTimeout,
-			MaxIdleConns:    config.ClientConfig.MaxIdleConns,
-		},
-	}
-	client, err := storage.NewClient(context.Background(), option.WithHTTPClient(&hc))
+	client, err := storage.NewClient(context.Background(), option.WithHTTPClient(httpClient(config.ClientConfig)))
 	if err != nil {
 		logger.WithError(err).Fatal("failed to create storage client instance")
 	}
@@ -49,6 +42,16 @@ func main() {
 	err = http.Serve(listener, handler)
 	if err != nil {
 		logger.WithError(err).Fatal("failed to start server")
+	}
+}
+
+func httpClient(c ClientConfig) *http.Client {
+	return &http.Client{
+		Timeout: c.Timeout,
+		Transport: &http.Transport{
+			IdleConnTimeout: c.IdleConnTimeout,
+			MaxIdleConns:    c.MaxIdleConns,
+		},
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/google/gops/agent"
 	"golang.org/x/net/context"
+	"google.golang.org/api/option"
 )
 
 const version = "1.5"
@@ -27,7 +28,14 @@ func main() {
 		log.Fatal(err)
 	}
 	logger := config.logger()
-	client, err := storage.NewClient(context.Background())
+	hc := http.Client{
+		Timeout: config.ClientConfig.Timeout,
+		Transport: &http.Transport{
+			IdleConnTimeout: config.ClientConfig.IdleConnTimeout,
+			MaxIdleConns:    config.ClientConfig.MaxIdleConns,
+		},
+	}
+	client, err := storage.NewClient(context.Background(), option.WithHTTPClient(&hc))
 	if err != nil {
 		logger.WithError(err).Fatal("failed to create storage client instance")
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestHTTPClient(t *testing.T) {
+	hc := httpClient(ClientConfig{
+		Timeout:         time.Minute,
+		IdleConnTimeout: 2 * time.Minute,
+		MaxIdleConns:    10,
+	})
+	expectedClient := http.Client{
+		Timeout: time.Minute,
+		Transport: &http.Transport{
+			MaxIdleConns:    10,
+			IdleConnTimeout: 2 * time.Minute,
+		},
+	}
+	ign := cmpopts.IgnoreUnexported(http.Transport{})
+	if !cmp.Equal(*hc, expectedClient, ign) {
+		t.Errorf("wrong client returned\n%s", cmp.Diff(*hc, expectedClient, ign))
+	}
+}

--- a/proxy.go
+++ b/proxy.go
@@ -39,7 +39,7 @@ func getProxyHandler(c Config, client *storage.Client) http.HandlerFunc {
 			return
 		}
 		resp := codeWrapper{ResponseWriter: w}
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithTimeout(context.Background(), c.ProxyTimeout)
 		defer cancel()
 		objectHandle := bucketHandle.Object(objectName)
 		var err error

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"net/http"
 	"testing"
+	"time"
 )
 
 func TestServerProxyOnly(t *testing.T) {
 	addr, cleanup := startServer(t, Config{
 		BucketName:      "my-bucket",
 		ProxyLogHeaders: []string{"Accept", "User-Agent", "Range"},
+		ProxyTimeout:    time.Second,
 	})
 	defer cleanup()
 	var tests = []serverTest{
@@ -103,7 +105,7 @@ func TestServerProxyOnly(t *testing.T) {
 }
 
 func TestServerProxyHandlerBucketNotFound(t *testing.T) {
-	addr, cleanup := startServer(t, Config{BucketName: "some-bucket"})
+	addr, cleanup := startServer(t, Config{BucketName: "some-bucket", ProxyTimeout: time.Second})
 	defer cleanup()
 	req, _ := http.NewRequest(http.MethodHead, addr+"/whatever", nil)
 	resp, err := http.DefaultClient.Do(req)

--- a/server_test.go
+++ b/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/fsouza/fake-gcs-server/fakestorage"
 )
@@ -16,6 +17,7 @@ func TestServerMultiPrefixes(t *testing.T) {
 		BucketName:    "my-bucket",
 		MapPrefix:     "/map/",
 		ProxyPrefix:   "/proxy/",
+		ProxyTimeout:  time.Second,
 		MapExtensions: []string{".mp3", ".txt"},
 	})
 	defer cleanup()

--- a/vendor/github.com/google/go-cmp/.travis.yml
+++ b/vendor/github.com/google/go-cmp/.travis.yml
@@ -1,0 +1,18 @@
+sudo: false
+language: go
+go:
+  - 1.x
+  - master
+matrix:
+  include:
+    - go: 1.6.x
+      script: go test -v -race ./...
+  allow_failures:
+    - go: master
+  fast_finish: true
+install:
+  - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (it is intended for this package to have no dependencies other than the standard library).
+script:
+  - diff -u <(echo -n) <(gofmt -d -s .)
+  - go tool vet .
+  - go test -v -race ./...

--- a/vendor/github.com/google/go-cmp/CONTRIBUTING.md
+++ b/vendor/github.com/google/go-cmp/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# How to Contribute
+
+We'd love to accept your patches and contributions to this project. There are
+just a few small guidelines you need to follow.
+
+## Contributor License Agreement
+
+Contributions to this project must be accompanied by a Contributor License
+Agreement. You (or your employer) retain the copyright to your contribution,
+this simply gives us permission to use and redistribute your contributions as
+part of the project. Head over to <https://cla.developers.google.com/> to see
+your current agreements on file or to sign a new one.
+
+You generally only need to submit a CLA once, so if you've already submitted one
+(even if it was for a different project), you probably don't need to do it
+again.
+
+## Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.

--- a/vendor/github.com/google/go-cmp/LICENSE
+++ b/vendor/github.com/google/go-cmp/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2017 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/google/go-cmp/README.md
+++ b/vendor/github.com/google/go-cmp/README.md
@@ -1,0 +1,41 @@
+# Package for equality of Go values
+
+[![GoDoc](https://godoc.org/github.com/google/go-cmp/cmp?status.svg)][godoc]
+[![Build Status](https://travis-ci.org/google/go-cmp.svg?branch=master)][travis]
+
+This package is intended to be a more powerful and safer alternative to
+`reflect.DeepEqual` for comparing whether two values are semantically equal.
+
+The primary features of cmp are:
+
+* When the default behavior of equality does not suit the needs of the test,
+  custom equality functions can override the equality operation.
+  For example, an equality function may report floats as equal so long as they
+  are within some tolerance of each other.
+
+* Types that have an `Equal` method may use that method to determine equality.
+  This allows package authors to determine the equality operation for the types
+  that they define.
+
+* If no custom equality functions are used and no `Equal` method is defined,
+  equality is determined by recursively comparing the primitive kinds on both
+  values, much like `reflect.DeepEqual`. Unlike `reflect.DeepEqual`, unexported
+  fields are not compared; they result in panics unless suppressed by using
+  an `Ignore` option.
+
+This is not an official Google product.
+
+[godoc]: https://godoc.org/github.com/google/go-cmp/cmp
+[travis]: https://travis-ci.org/google/go-cmp
+
+## Install
+
+```
+go get -u github.com/google/go-cmp/cmp
+```
+
+## License
+
+BSD - See [LICENSE][license] file
+
+[license]: https://github.com/google/go-cmp/blob/master/LICENSE

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/equate.go
@@ -1,0 +1,89 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package cmpopts provides common options for the cmp package.
+package cmpopts
+
+import (
+	"math"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func equateAlways(_, _ interface{}) bool { return true }
+
+// EquateEmpty returns a Comparer option that determines all maps and slices
+// with a length of zero to be equal, regardless of whether they are nil.
+//
+// EquateEmpty can be used in conjuction with SortSlices and SortMaps.
+func EquateEmpty() cmp.Option {
+	return cmp.FilterValues(isEmpty, cmp.Comparer(equateAlways))
+}
+
+func isEmpty(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+		(vx.Len() == 0 && vy.Len() == 0)
+}
+
+// EquateApprox returns a Comparer option that determines float32 or float64
+// values to be equal if they are within a relative fraction or absolute margin.
+// This option is not used when either x or y is NaN or infinite.
+//
+// The fraction determines that the difference of two values must be within the
+// smaller fraction of the two values, while the margin determines that the two
+// values must be within some absolute margin.
+// To express only a fraction or only a margin, use 0 for the other parameter.
+// The fraction and margin must be non-negative.
+//
+// The mathematical expression used is equivalent to:
+//	|x-y| ≤ max(fraction*min(|x|, |y|), margin)
+//
+// EquateApprox can be used in conjuction with EquateNaNs.
+func EquateApprox(fraction, margin float64) cmp.Option {
+	if margin < 0 || fraction < 0 || math.IsNaN(margin) || math.IsNaN(fraction) {
+		panic("margin or fraction must be a non-negative number")
+	}
+	a := approximator{fraction, margin}
+	return cmp.Options{
+		cmp.FilterValues(areRealF64s, cmp.Comparer(a.compareF64)),
+		cmp.FilterValues(areRealF32s, cmp.Comparer(a.compareF32)),
+	}
+}
+
+type approximator struct{ frac, marg float64 }
+
+func areRealF64s(x, y float64) bool {
+	return !math.IsNaN(x) && !math.IsNaN(y) && !math.IsInf(x, 0) && !math.IsInf(y, 0)
+}
+func areRealF32s(x, y float32) bool {
+	return areRealF64s(float64(x), float64(y))
+}
+func (a approximator) compareF64(x, y float64) bool {
+	relMarg := a.frac * math.Min(math.Abs(x), math.Abs(y))
+	return math.Abs(x-y) <= math.Max(a.marg, relMarg)
+}
+func (a approximator) compareF32(x, y float32) bool {
+	return a.compareF64(float64(x), float64(y))
+}
+
+// EquateNaNs returns a Comparer option that determines float32 and float64
+// NaN values to be equal.
+//
+// EquateNaNs can be used in conjuction with EquateApprox.
+func EquateNaNs() cmp.Option {
+	return cmp.Options{
+		cmp.FilterValues(areNaNsF64s, cmp.Comparer(equateAlways)),
+		cmp.FilterValues(areNaNsF32s, cmp.Comparer(equateAlways)),
+	}
+}
+
+func areNaNsF64s(x, y float64) bool {
+	return math.IsNaN(x) && math.IsNaN(y)
+}
+func areNaNsF32s(x, y float32) bool {
+	return areNaNsF64s(float64(x), float64(y))
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/ignore.go
@@ -1,0 +1,148 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// IgnoreFields returns an Option that ignores exported fields of the
+// given names on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to ignore a
+// specific sub-field that is embedded or nested within the parent struct.
+//
+// This does not handle unexported fields; use IgnoreUnexported instead.
+func IgnoreFields(typ interface{}, names ...string) cmp.Option {
+	sf := newStructFilter(typ, names...)
+	return cmp.FilterPath(sf.filter, cmp.Ignore())
+}
+
+// IgnoreTypes returns an Option that ignores all values assignable to
+// certain types, which are specified by passing in a value of each type.
+func IgnoreTypes(typs ...interface{}) cmp.Option {
+	tf := newTypeFilter(typs...)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type typeFilter []reflect.Type
+
+func newTypeFilter(typs ...interface{}) (tf typeFilter) {
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil {
+			// This occurs if someone tries to pass in sync.Locker(nil)
+			panic("cannot determine type; consider using IgnoreInterfaces")
+		}
+		tf = append(tf, t)
+	}
+	return tf
+}
+func (tf typeFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p[len(p)-1].Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreInterfaces returns an Option that ignores all values or references of
+// values assignable to certain interface types. These interfaces are specified
+// by passing in an anonymous struct with the interface types embedded in it.
+// For example, to ignore sync.Locker, pass in struct{sync.Locker}{}.
+func IgnoreInterfaces(ifaces interface{}) cmp.Option {
+	tf := newIfaceFilter(ifaces)
+	return cmp.FilterPath(tf.filter, cmp.Ignore())
+}
+
+type ifaceFilter []reflect.Type
+
+func newIfaceFilter(ifaces interface{}) (tf ifaceFilter) {
+	t := reflect.TypeOf(ifaces)
+	if ifaces == nil || t.Name() != "" || t.Kind() != reflect.Struct {
+		panic("input must be an anonymous struct")
+	}
+	for i := 0; i < t.NumField(); i++ {
+		fi := t.Field(i)
+		switch {
+		case !fi.Anonymous:
+			panic("struct cannot have named fields")
+		case fi.Type.Kind() != reflect.Interface:
+			panic("embedded field must be an interface type")
+		case fi.Type.NumMethod() == 0:
+			// This matches everything; why would you ever want this?
+			panic("cannot ignore empty interface")
+		default:
+			tf = append(tf, fi.Type)
+		}
+	}
+	return tf
+}
+func (tf ifaceFilter) filter(p cmp.Path) bool {
+	if len(p) < 1 {
+		return false
+	}
+	t := p[len(p)-1].Type()
+	for _, ti := range tf {
+		if t.AssignableTo(ti) {
+			return true
+		}
+		if t.Kind() != reflect.Ptr && reflect.PtrTo(t).AssignableTo(ti) {
+			return true
+		}
+	}
+	return false
+}
+
+// IgnoreUnexported returns an Option that only ignores the immediate unexported
+// fields of a struct, including anonymous fields of unexported types.
+// In particular, unexported fields within the struct's exported fields
+// of struct types, including anonymous fields, will not be ignored unless the
+// type of the field itself is also passed to IgnoreUnexported.
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	ux := newUnexportedFilter(typs...)
+	return cmp.FilterPath(ux.filter, cmp.Ignore())
+}
+
+type unexportedFilter struct{ m map[reflect.Type]bool }
+
+func newUnexportedFilter(typs ...interface{}) unexportedFilter {
+	ux := unexportedFilter{m: make(map[reflect.Type]bool)}
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t == nil || t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("invalid struct type: %T", typ))
+		}
+		ux.m[t] = true
+	}
+	return ux
+}
+func (xf unexportedFilter) filter(p cmp.Path) bool {
+	if len(p) < 2 {
+		return false
+	}
+	sf, ok := p[len(p)-1].(cmp.StructField)
+	if !ok {
+		return false
+	}
+	return xf.m[p[len(p)-2].Type()] && !isExported(sf.Name())
+}
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort.go
@@ -1,0 +1,155 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// SortSlices returns a Transformer option that sorts all []V.
+// The less function must be of the form "func(T, T) bool" which is used to
+// sort any slice with element type V that is assignable to T.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//
+// The less function does not have to be "total". That is, if !less(x, y) and
+// !less(y, x) for two elements x and y, their relative order is maintained.
+//
+// SortSlices can be used in conjuction with EquateEmpty.
+func SortSlices(less interface{}) cmp.Option {
+	vf := reflect.ValueOf(less)
+	if !isTTBoolFunc(vf.Type()) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", less))
+	}
+	ss := sliceSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ss.filter, cmp.Transformer("Sort", ss.sort))
+}
+
+type sliceSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ss sliceSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	if !(x != nil && y != nil && vx.Type() == vy.Type()) ||
+		!(vx.Kind() == reflect.Slice && vx.Type().Elem().AssignableTo(ss.in)) ||
+		(vx.Len() <= 1 && vy.Len() <= 1) {
+		return false
+	}
+	// Check whether the slices are already sorted to avoid an infinite
+	// recursion cycle applying the same transform to itself.
+	ok1 := sliceIsSorted(x, func(i, j int) bool { return ss.less(vx, i, j) })
+	ok2 := sliceIsSorted(y, func(i, j int) bool { return ss.less(vy, i, j) })
+	return !ok1 || !ok2
+}
+func (ss sliceSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	dst := reflect.MakeSlice(src.Type(), src.Len(), src.Len())
+	for i := 0; i < src.Len(); i++ {
+		dst.Index(i).Set(src.Index(i))
+	}
+	sortSliceStable(dst.Interface(), func(i, j int) bool { return ss.less(dst, i, j) })
+	ss.checkSort(dst)
+	return dst.Interface()
+}
+func (ss sliceSorter) checkSort(v reflect.Value) {
+	start := -1 // Start of a sequence of equal elements.
+	for i := 1; i < v.Len(); i++ {
+		if ss.less(v, i-1, i) {
+			// Check that first and last elements in v[start:i] are equal.
+			if start >= 0 && (ss.less(v, start, i-1) || ss.less(v, i-1, start)) {
+				panic(fmt.Sprintf("incomparable values detected: want equal elements: %v", v.Slice(start, i)))
+			}
+			start = -1
+		} else if start == -1 {
+			start = i
+		}
+	}
+}
+func (ss sliceSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i), v.Index(j)
+	return ss.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+// SortMaps returns a Transformer option that flattens map[K]V types to be a
+// sorted []struct{K, V}. The less function must be of the form
+// "func(T, T) bool" which is used to sort any map with key K that is
+// assignable to T.
+//
+// Flattening the map into a slice has the property that cmp.Equal is able to
+// use Comparers on K or the K.Equal method if it exists.
+//
+// The less function must be:
+//	• Deterministic: less(x, y) == less(x, y)
+//	• Irreflexive: !less(x, x)
+//	• Transitive: if !less(x, y) and !less(y, z), then !less(x, z)
+//	• Total: if x != y, then either less(x, y) or less(y, x)
+//
+// SortMaps can be used in conjuction with EquateEmpty.
+func SortMaps(less interface{}) cmp.Option {
+	vf := reflect.ValueOf(less)
+	if !isTTBoolFunc(vf.Type()) || vf.IsNil() {
+		panic(fmt.Sprintf("invalid less function: %T", less))
+	}
+	ms := mapSorter{vf.Type().In(0), vf}
+	return cmp.FilterValues(ms.filter, cmp.Transformer("Sort", ms.sort))
+}
+
+type mapSorter struct {
+	in  reflect.Type  // T
+	fnc reflect.Value // func(T, T) bool
+}
+
+func (ms mapSorter) filter(x, y interface{}) bool {
+	vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+	return (x != nil && y != nil && vx.Type() == vy.Type()) &&
+		(vx.Kind() == reflect.Map && vx.Type().Key().AssignableTo(ms.in)) &&
+		(vx.Len() != 0 || vy.Len() != 0)
+}
+func (ms mapSorter) sort(x interface{}) interface{} {
+	src := reflect.ValueOf(x)
+	outType := mapEntryType(src.Type())
+	dst := reflect.MakeSlice(reflect.SliceOf(outType), src.Len(), src.Len())
+	for i, k := range src.MapKeys() {
+		v := reflect.New(outType).Elem()
+		v.Field(0).Set(k)
+		v.Field(1).Set(src.MapIndex(k))
+		dst.Index(i).Set(v)
+	}
+	sortSlice(dst.Interface(), func(i, j int) bool { return ms.less(dst, i, j) })
+	ms.checkSort(dst)
+	return dst.Interface()
+}
+func (ms mapSorter) checkSort(v reflect.Value) {
+	for i := 1; i < v.Len(); i++ {
+		if !ms.less(v, i-1, i) {
+			panic(fmt.Sprintf("partial order detected: want %v < %v", v.Index(i-1), v.Index(i)))
+		}
+	}
+}
+func (ms mapSorter) less(v reflect.Value, i, j int) bool {
+	vx, vy := v.Index(i).Field(0), v.Index(j).Field(0)
+	if !hasReflectStructOf {
+		vx, vy = vx.Elem(), vy.Elem()
+	}
+	return ms.fnc.Call([]reflect.Value{vx, vy})[0].Bool()
+}
+
+var boolType = reflect.TypeOf(true)
+
+// isTTBoolFunc reports whether f is of the form: func(T, T) bool.
+func isTTBoolFunc(t reflect.Type) bool {
+	if t == nil || t.Kind() != reflect.Func || t.IsVariadic() {
+		return false
+	}
+	return t.NumIn() == 2 && t.NumOut() == 1 && t.In(0) == t.In(1) && t.Out(0) == boolType
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort_go17.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort_go17.go
@@ -1,0 +1,46 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build !go1.8
+
+package cmpopts
+
+import (
+	"reflect"
+	"sort"
+)
+
+const hasReflectStructOf = false
+
+func mapEntryType(reflect.Type) reflect.Type {
+	return reflect.TypeOf(struct{ K, V interface{} }{})
+}
+
+func sliceIsSorted(slice interface{}, less func(i, j int) bool) bool {
+	return sort.IsSorted(reflectSliceSorter{reflect.ValueOf(slice), less})
+}
+func sortSlice(slice interface{}, less func(i, j int) bool) {
+	sort.Sort(reflectSliceSorter{reflect.ValueOf(slice), less})
+}
+func sortSliceStable(slice interface{}, less func(i, j int) bool) {
+	sort.Stable(reflectSliceSorter{reflect.ValueOf(slice), less})
+}
+
+type reflectSliceSorter struct {
+	slice reflect.Value
+	less  func(i, j int) bool
+}
+
+func (ss reflectSliceSorter) Len() int {
+	return ss.slice.Len()
+}
+func (ss reflectSliceSorter) Less(i, j int) bool {
+	return ss.less(i, j)
+}
+func (ss reflectSliceSorter) Swap(i, j int) {
+	vi := ss.slice.Index(i).Interface()
+	vj := ss.slice.Index(j).Interface()
+	ss.slice.Index(i).Set(reflect.ValueOf(vj))
+	ss.slice.Index(j).Set(reflect.ValueOf(vi))
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/sort_go18.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/sort_go18.go
@@ -1,0 +1,31 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build go1.8
+
+package cmpopts
+
+import (
+	"reflect"
+	"sort"
+)
+
+const hasReflectStructOf = true
+
+func mapEntryType(t reflect.Type) reflect.Type {
+	return reflect.StructOf([]reflect.StructField{
+		{Name: "K", Type: t.Key()},
+		{Name: "V", Type: t.Elem()},
+	})
+}
+
+func sliceIsSorted(slice interface{}, less func(i, j int) bool) bool {
+	return sort.SliceIsSorted(slice, less)
+}
+func sortSlice(slice interface{}, less func(i, j int) bool) {
+	sort.Slice(slice, less)
+}
+func sortSliceStable(slice interface{}, less func(i, j int) bool) {
+	sort.SliceStable(slice, less)
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/struct_filter.go
@@ -1,0 +1,182 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// filterField returns a new Option where opt is only evaluated on paths that
+// include a specific exported field on a single struct type.
+// The struct type is specified by passing in a value of that type.
+//
+// The name may be a dot-delimited string (e.g., "Foo.Bar") to select a
+// specific sub-field that is embedded or nested within the parent struct.
+func filterField(typ interface{}, name string, opt cmp.Option) cmp.Option {
+	// TODO: This is currently unexported over concerns of how helper filters
+	// can be composed together easily.
+	// TODO: Add tests for FilterField.
+
+	sf := newStructFilter(typ, name)
+	return cmp.FilterPath(sf.filter, opt)
+}
+
+type structFilter struct {
+	t  reflect.Type // The root struct type to match on
+	ft fieldTree    // Tree of fields to match on
+}
+
+func newStructFilter(typ interface{}, names ...string) structFilter {
+	// TODO: Perhaps allow * as a special identifier to allow ignoring any
+	// number of path steps until the next field match?
+	// This could be useful when a concrete struct gets transformed into
+	// an anonymous struct where it is not possible to specify that by type,
+	// but the transformer happens to provide guarantees about the names of
+	// the transformed fields.
+
+	t := reflect.TypeOf(typ)
+	if t == nil || t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("%T must be a struct", typ))
+	}
+	var ft fieldTree
+	for _, name := range names {
+		cname, err := canonicalName(t, name)
+		if err != nil {
+			panic(fmt.Sprintf("%s: %v", strings.Join(cname, "."), err))
+		}
+		ft.insert(cname)
+	}
+	return structFilter{t, ft}
+}
+
+func (sf structFilter) filter(p cmp.Path) bool {
+	for i, ps := range p {
+		if ps.Type().AssignableTo(sf.t) && sf.ft.matchPrefix(p[i+1:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// fieldTree represents a set of dot-separated identifiers.
+//
+// For example, inserting the following selectors:
+//	Foo
+//	Foo.Bar.Baz
+//	Foo.Buzz
+//	Nuka.Cola.Quantum
+//
+// Results in a tree of the form:
+//	{sub: {
+//		"Foo": {ok: true, sub: {
+//			"Bar": {sub: {
+//				"Baz": {ok: true},
+//			}},
+//			"Buzz": {ok: true},
+//		}},
+//		"Nuka": {sub: {
+//			"Cola": {sub: {
+//				"Quantum": {ok: true},
+//			}},
+//		}},
+//	}}
+type fieldTree struct {
+	ok  bool                 // Whether this is a specified node
+	sub map[string]fieldTree // The sub-tree of fields under this node
+}
+
+// insert inserts a sequence of field accesses into the tree.
+func (ft *fieldTree) insert(cname []string) {
+	if ft.sub == nil {
+		ft.sub = make(map[string]fieldTree)
+	}
+	if len(cname) == 0 {
+		ft.ok = true
+		return
+	}
+	sub := ft.sub[cname[0]]
+	sub.insert(cname[1:])
+	ft.sub[cname[0]] = sub
+}
+
+// matchPrefix reports whether any selector in the fieldTree matches
+// the start of path p.
+func (ft fieldTree) matchPrefix(p cmp.Path) bool {
+	for _, ps := range p {
+		switch ps := ps.(type) {
+		case cmp.StructField:
+			ft = ft.sub[ps.Name()]
+			if ft.ok {
+				return true
+			}
+			if len(ft.sub) == 0 {
+				return false
+			}
+		case cmp.Indirect:
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// canonicalName returns a list of identifiers where any struct field access
+// through an embedded field is expanded to include the names of the embedded
+// types themselves.
+//
+// For example, suppose field "Foo" is not directly in the parent struct,
+// but actually from an embedded struct of type "Bar". Then, the canonical name
+// of "Foo" is actually "Bar.Foo".
+//
+// Suppose field "Foo" is not directly in the parent struct, but actually
+// a field in two different embedded structs of types "Bar" and "Baz".
+// Then the selector "Foo" causes a panic since it is ambiguous which one it
+// refers to. The user must specify either "Bar.Foo" or "Baz.Foo".
+func canonicalName(t reflect.Type, sel string) ([]string, error) {
+	var name string
+	sel = strings.TrimPrefix(sel, ".")
+	if sel == "" {
+		return nil, fmt.Errorf("name must not be empty")
+	}
+	if i := strings.IndexByte(sel, '.'); i < 0 {
+		name, sel = sel, ""
+	} else {
+		name, sel = sel[:i], sel[i:]
+	}
+
+	// Type must be a struct or pointer to struct.
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("%v must be a struct", t)
+	}
+
+	// Find the canonical name for this current field name.
+	// If the field exists in an embedded struct, then it will be expanded.
+	if !isExported(name) {
+		// Disallow unexported fields:
+		//	* To discourage people from actually touching unexported fields
+		//	* FieldByName is buggy (https://golang.org/issue/4876)
+		return []string{name}, fmt.Errorf("name must be exported")
+	}
+	sf, ok := t.FieldByName(name)
+	if !ok {
+		return []string{name}, fmt.Errorf("does not exist")
+	}
+	var ss []string
+	for i := range sf.Index {
+		ss = append(ss, t.FieldByIndex(sf.Index[:i+1]).Name)
+	}
+	if sel == "" {
+		return ss, nil
+	}
+	ssPost, err := canonicalName(sf.Type, sel)
+	return append(ss, ssPost...), err
+}

--- a/vendor/github.com/google/go-cmp/cmp/cmpopts/util_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/cmpopts/util_test.go
@@ -1,0 +1,996 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmpopts
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type (
+	MyInt    int
+	MyFloat  float32
+	MyTime   struct{ time.Time }
+	MyStruct struct {
+		A, B []int
+		C, D map[time.Time]string
+	}
+
+	Foo1 struct{ Alpha, Bravo, Charlie int }
+	Foo2 struct{ *Foo1 }
+	Foo3 struct{ *Foo2 }
+	Bar1 struct{ Foo3 }
+	Bar2 struct {
+		Bar1
+		*Foo3
+		Bravo float32
+	}
+	Bar3 struct {
+		Bar1
+		Bravo *Bar2
+		Delta struct{ Echo Foo1 }
+		*Foo3
+		Alpha string
+	}
+
+	privateStruct struct{ Public, private int }
+	PublicStruct  struct{ Public, private int }
+	ParentStruct  struct {
+		*privateStruct
+		*PublicStruct
+		Public  int
+		private int
+	}
+
+	Everything struct {
+		MyInt
+		MyFloat
+		MyTime
+		MyStruct
+		Bar3
+		ParentStruct
+	}
+
+	EmptyInterface interface{}
+)
+
+func TestOptions(t *testing.T) {
+	createBar3X := func() *Bar3 {
+		return &Bar3{
+			Bar1: Bar1{Foo3{&Foo2{&Foo1{Bravo: 2}}}},
+			Bravo: &Bar2{
+				Bar1:  Bar1{Foo3{&Foo2{&Foo1{Charlie: 7}}}},
+				Foo3:  &Foo3{&Foo2{&Foo1{Bravo: 5}}},
+				Bravo: 4,
+			},
+			Delta: struct{ Echo Foo1 }{Foo1{Charlie: 3}},
+			Foo3:  &Foo3{&Foo2{&Foo1{Alpha: 1}}},
+			Alpha: "alpha",
+		}
+	}
+	createBar3Y := func() *Bar3 {
+		return &Bar3{
+			Bar1: Bar1{Foo3{&Foo2{&Foo1{Bravo: 3}}}},
+			Bravo: &Bar2{
+				Bar1:  Bar1{Foo3{&Foo2{&Foo1{Charlie: 8}}}},
+				Foo3:  &Foo3{&Foo2{&Foo1{Bravo: 6}}},
+				Bravo: 5,
+			},
+			Delta: struct{ Echo Foo1 }{Foo1{Charlie: 4}},
+			Foo3:  &Foo3{&Foo2{&Foo1{Alpha: 2}}},
+			Alpha: "ALPHA",
+		}
+	}
+
+	tests := []struct {
+		label     string       // Test name
+		x, y      interface{}  // Input values to compare
+		opts      []cmp.Option // Input options
+		wantEqual bool         // Whether the inputs are equal
+		wantPanic bool         // Whether Equal should panic
+		reason    string       // The reason for the expected outcome
+	}{{
+		label:     "EquateEmpty",
+		x:         []int{},
+		y:         []int(nil),
+		wantEqual: false,
+		reason:    "not equal because empty non-nil and nil slice differ",
+	}, {
+		label:     "EquateEmpty",
+		x:         []int{},
+		y:         []int(nil),
+		opts:      []cmp.Option{EquateEmpty()},
+		wantEqual: true,
+		reason:    "equal because EquateEmpty equates empty slices",
+	}, {
+		label:     "SortSlices",
+		x:         []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		y:         []int{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
+		wantEqual: false,
+		reason:    "not equal because element order differs",
+	}, {
+		label:     "SortSlices",
+		x:         []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		y:         []int{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
+		opts:      []cmp.Option{SortSlices(func(x, y int) bool { return x < y })},
+		wantEqual: true,
+		reason:    "equal because SortSlices sorts the slices",
+	}, {
+		label:     "SortSlices",
+		x:         []MyInt{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+		y:         []MyInt{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
+		opts:      []cmp.Option{SortSlices(func(x, y int) bool { return x < y })},
+		wantEqual: false,
+		reason:    "not equal because MyInt is not the same type as int",
+	}, {
+		label:     "SortSlices",
+		x:         []float64{0, 1, 1, 2, 2, 2},
+		y:         []float64{2, 0, 2, 1, 2, 1},
+		opts:      []cmp.Option{SortSlices(func(x, y float64) bool { return x < y })},
+		wantEqual: true,
+		reason:    "equal even when sorted with duplicate elements",
+	}, {
+		label:     "SortSlices",
+		x:         []float64{0, 1, 1, 2, 2, 2, math.NaN(), 3, 3, 3, 3, 4, 4, 4, 4},
+		y:         []float64{2, 0, 4, 4, 3, math.NaN(), 4, 1, 3, 2, 3, 3, 4, 1, 2},
+		opts:      []cmp.Option{SortSlices(func(x, y float64) bool { return x < y })},
+		wantPanic: true,
+		reason:    "panics because SortSlices used with non-transitive less function",
+	}, {
+		label: "SortSlices",
+		x:     []float64{0, 1, 1, 2, 2, 2, math.NaN(), 3, 3, 3, 3, 4, 4, 4, 4},
+		y:     []float64{2, 0, 4, 4, 3, math.NaN(), 4, 1, 3, 2, 3, 3, 4, 1, 2},
+		opts: []cmp.Option{SortSlices(func(x, y float64) bool {
+			return (!math.IsNaN(x) && math.IsNaN(y)) || x < y
+		})},
+		wantEqual: false,
+		reason:    "no panics because SortSlices used with valid less function; not equal because NaN != NaN",
+	}, {
+		label: "SortSlices+EquateNaNs",
+		x:     []float64{0, 1, 1, 2, 2, 2, math.NaN(), 3, 3, 3, math.NaN(), 3, 4, 4, 4, 4},
+		y:     []float64{2, 0, 4, 4, 3, math.NaN(), 4, 1, 3, 2, 3, 3, 4, 1, math.NaN(), 2},
+		opts: []cmp.Option{
+			EquateNaNs(),
+			SortSlices(func(x, y float64) bool {
+				return (!math.IsNaN(x) && math.IsNaN(y)) || x < y
+			}),
+		},
+		wantEqual: true,
+		reason:    "no panics because SortSlices used with valid less function; equal because EquateNaNs is used",
+	}, {
+		label: "SortMaps",
+		x: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC): "2nd birthday",
+		},
+		y: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "2nd birthday",
+		},
+		wantEqual: false,
+		reason:    "not equal because timezones differ",
+	}, {
+		label: "SortMaps",
+		x: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC): "2nd birthday",
+		},
+		y: map[time.Time]string{
+			time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "0th birthday",
+			time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "1st birthday",
+			time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "2nd birthday",
+		},
+		opts:      []cmp.Option{SortMaps(func(x, y time.Time) bool { return x.Before(y) })},
+		wantEqual: true,
+		reason:    "equal because SortMaps flattens to a slice where Time.Equal can be used",
+	}, {
+		label: "SortMaps",
+		x: map[MyTime]string{
+			{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)}: "0th birthday",
+			{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC)}: "1st birthday",
+			{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC)}: "2nd birthday",
+		},
+		y: map[MyTime]string{
+			{time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "0th birthday",
+			{time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "1st birthday",
+			{time.Date(2011, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local)}: "2nd birthday",
+		},
+		opts:      []cmp.Option{SortMaps(func(x, y time.Time) bool { return x.Before(y) })},
+		wantEqual: false,
+		reason:    "not equal because MyTime is not assignable to time.Time",
+	}, {
+		label: "SortMaps",
+		x:     map[int]string{-3: "", -2: "", -1: "", 0: "", 1: "", 2: "", 3: ""},
+		// => {0, 1, 2, 3, -1, -2, -3},
+		y: map[int]string{300: "", 200: "", 100: "", 0: "", 1: "", 2: "", 3: ""},
+		// => {0, 1, 2, 3, 100, 200, 300},
+		opts: []cmp.Option{SortMaps(func(a, b int) bool {
+			if -10 < a && a <= 0 {
+				a *= -100
+			}
+			if -10 < b && b <= 0 {
+				b *= -100
+			}
+			return a < b
+		})},
+		wantEqual: false,
+		reason:    "not equal because values differ even though SortMap provides valid ordering",
+	}, {
+		label: "SortMaps",
+		x:     map[int]string{-3: "", -2: "", -1: "", 0: "", 1: "", 2: "", 3: ""},
+		// => {0, 1, 2, 3, -1, -2, -3},
+		y: map[int]string{300: "", 200: "", 100: "", 0: "", 1: "", 2: "", 3: ""},
+		// => {0, 1, 2, 3, 100, 200, 300},
+		opts: []cmp.Option{
+			SortMaps(func(x, y int) bool {
+				if -10 < x && x <= 0 {
+					x *= -100
+				}
+				if -10 < y && y <= 0 {
+					y *= -100
+				}
+				return x < y
+			}),
+			cmp.Comparer(func(x, y int) bool {
+				if -10 < x && x <= 0 {
+					x *= -100
+				}
+				if -10 < y && y <= 0 {
+					y *= -100
+				}
+				return x == y
+			}),
+		},
+		wantEqual: true,
+		reason:    "equal because Comparer used to equate differences",
+	}, {
+		label: "SortMaps",
+		x:     map[int]string{-3: "", -2: "", -1: "", 0: "", 1: "", 2: "", 3: ""},
+		y:     map[int]string{},
+		opts: []cmp.Option{SortMaps(func(x, y int) bool {
+			return x < y && x >= 0 && y >= 0
+		})},
+		wantPanic: true,
+		reason:    "panics because SortMaps used with non-transitive less function",
+	}, {
+		label: "SortMaps",
+		x:     map[int]string{-3: "", -2: "", -1: "", 0: "", 1: "", 2: "", 3: ""},
+		y:     map[int]string{},
+		opts: []cmp.Option{SortMaps(func(x, y int) bool {
+			return math.Abs(float64(x)) < math.Abs(float64(y))
+		})},
+		wantPanic: true,
+		reason:    "panics because SortMaps used with partial less function",
+	}, {
+		label: "EquateEmpty+SortSlices+SortMaps",
+		x: MyStruct{
+			A: []int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
+			C: map[time.Time]string{
+				time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC): "0th birthday",
+				time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC): "1st birthday",
+			},
+			D: map[time.Time]string{},
+		},
+		y: MyStruct{
+			A: []int{1, 0, 5, 2, 8, 9, 4, 3, 6, 7},
+			B: []int{},
+			C: map[time.Time]string{
+				time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "0th birthday",
+				time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC).In(time.Local): "1st birthday",
+			},
+		},
+		opts: []cmp.Option{
+			EquateEmpty(),
+			SortSlices(func(x, y int) bool { return x < y }),
+			SortMaps(func(x, y time.Time) bool { return x.Before(y) }),
+		},
+		wantEqual: true,
+		reason:    "no panics because EquateEmpty should compose with the sort options",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		wantEqual: false,
+		reason:    "not equal because floats do not exactly matches",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		opts:      []cmp.Option{EquateApprox(0, 0)},
+		wantEqual: false,
+		reason:    "not equal because EquateApprox(0 ,0) is equivalent to using ==",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		opts:      []cmp.Option{EquateApprox(0.003, 0.009)},
+		wantEqual: false,
+		reason:    "not equal because EquateApprox is too strict",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		opts:      []cmp.Option{EquateApprox(0, 0.011)},
+		wantEqual: true,
+		reason:    "equal because margin is loose enough to match",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		opts:      []cmp.Option{EquateApprox(0.004, 0)},
+		wantEqual: true,
+		reason:    "equal because fraction is loose enough to match",
+	}, {
+		label:     "EquateApprox",
+		x:         3.09,
+		y:         3.10,
+		opts:      []cmp.Option{EquateApprox(0.004, 0.011)},
+		wantEqual: true,
+		reason:    "equal because both the margin and fraction are loose enough to match",
+	}, {
+		label:     "EquateApprox",
+		x:         float32(3.09),
+		y:         float64(3.10),
+		opts:      []cmp.Option{EquateApprox(0.004, 0)},
+		wantEqual: false,
+		reason:    "not equal because the types differ",
+	}, {
+		label:     "EquateApprox",
+		x:         float32(3.09),
+		y:         float32(3.10),
+		opts:      []cmp.Option{EquateApprox(0.004, 0)},
+		wantEqual: true,
+		reason:    "equal because EquateApprox also applies on float32s",
+	}, {
+		label:     "EquateApprox",
+		x:         []float64{math.Inf(+1), math.Inf(-1)},
+		y:         []float64{math.Inf(+1), math.Inf(-1)},
+		opts:      []cmp.Option{EquateApprox(0, 1)},
+		wantEqual: true,
+		reason:    "equal because we fall back on == which matches Inf (EquateApprox does not apply on Inf) ",
+	}, {
+		label:     "EquateApprox",
+		x:         []float64{math.Inf(+1), -1e100},
+		y:         []float64{+1e100, math.Inf(-1)},
+		opts:      []cmp.Option{EquateApprox(0, 1)},
+		wantEqual: false,
+		reason:    "not equal because we fall back on == where Inf != 1e100 (EquateApprox does not apply on Inf)",
+	}, {
+		label:     "EquateApprox",
+		x:         float64(+1e100),
+		y:         float64(-1e100),
+		opts:      []cmp.Option{EquateApprox(math.Inf(+1), 0)},
+		wantEqual: true,
+		reason:    "equal because infinite fraction matches everything",
+	}, {
+		label:     "EquateApprox",
+		x:         float64(+1e100),
+		y:         float64(-1e100),
+		opts:      []cmp.Option{EquateApprox(0, math.Inf(+1))},
+		wantEqual: true,
+		reason:    "equal because infinite margin matches everything",
+	}, {
+		label:     "EquateApprox",
+		x:         math.Pi,
+		y:         math.Pi,
+		opts:      []cmp.Option{EquateApprox(0, 0)},
+		wantEqual: true,
+		reason:    "equal because EquateApprox(0, 0) is equivalent to ==",
+	}, {
+		label:     "EquateApprox",
+		x:         math.Pi,
+		y:         math.Nextafter(math.Pi, math.Inf(+1)),
+		opts:      []cmp.Option{EquateApprox(0, 0)},
+		wantEqual: false,
+		reason:    "not equal because EquateApprox(0, 0) is equivalent to ==",
+	}, {
+		label:     "EquateNaNs",
+		x:         []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1)},
+		y:         []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1)},
+		wantEqual: false,
+		reason:    "not equal because NaN != NaN",
+	}, {
+		label:     "EquateNaNs",
+		x:         []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1)},
+		y:         []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1)},
+		opts:      []cmp.Option{EquateNaNs()},
+		wantEqual: true,
+		reason:    "equal because EquateNaNs allows NaN == NaN",
+	}, {
+		label:     "EquateNaNs",
+		x:         []float32{1.0, float32(math.NaN()), math.E, -0.0, +0.0},
+		y:         []float32{1.0, float32(math.NaN()), math.E, -0.0, +0.0},
+		opts:      []cmp.Option{EquateNaNs()},
+		wantEqual: true,
+		reason:    "equal because EquateNaNs operates on float32",
+	}, {
+		label: "EquateApprox+EquateNaNs",
+		x:     []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1), 1.01, 5001},
+		y:     []float64{1.0, math.NaN(), math.E, -0.0, +0.0, math.Inf(+1), math.Inf(-1), 1.02, 5002},
+		opts: []cmp.Option{
+			EquateNaNs(),
+			EquateApprox(0.01, 0),
+		},
+		wantEqual: true,
+		reason:    "equal because EquateNaNs and EquateApprox compose together",
+	}, {
+		label: "EquateApprox+EquateNaNs",
+		x:     []MyFloat{1.0, MyFloat(math.NaN()), MyFloat(math.E), -0.0, +0.0, MyFloat(math.Inf(+1)), MyFloat(math.Inf(-1)), 1.01, 5001},
+		y:     []MyFloat{1.0, MyFloat(math.NaN()), MyFloat(math.E), -0.0, +0.0, MyFloat(math.Inf(+1)), MyFloat(math.Inf(-1)), 1.02, 5002},
+		opts: []cmp.Option{
+			EquateNaNs(),
+			EquateApprox(0.01, 0),
+		},
+		wantEqual: false,
+		reason:    "not equal because EquateApprox and EquateNaNs do not apply on a named type",
+	}, {
+		label: "EquateApprox+EquateNaNs+Transform",
+		x:     []MyFloat{1.0, MyFloat(math.NaN()), MyFloat(math.E), -0.0, +0.0, MyFloat(math.Inf(+1)), MyFloat(math.Inf(-1)), 1.01, 5001},
+		y:     []MyFloat{1.0, MyFloat(math.NaN()), MyFloat(math.E), -0.0, +0.0, MyFloat(math.Inf(+1)), MyFloat(math.Inf(-1)), 1.02, 5002},
+		opts: []cmp.Option{
+			cmp.Transformer("", func(x MyFloat) float64 { return float64(x) }),
+			EquateNaNs(),
+			EquateApprox(0.01, 0),
+		},
+		wantEqual: true,
+		reason:    "equal because named type is transformed to float64",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		wantEqual: false,
+		reason:    "not equal because values do not match in deeply embedded field",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		opts:      []cmp.Option{IgnoreFields(Bar1{}, "Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreField ignores deeply embedded field: Alpha",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		opts:      []cmp.Option{IgnoreFields(Bar1{}, "Foo1.Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreField ignores deeply embedded field: Foo1.Alpha",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		opts:      []cmp.Option{IgnoreFields(Bar1{}, "Foo2.Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreField ignores deeply embedded field: Foo2.Alpha",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		opts:      []cmp.Option{IgnoreFields(Bar1{}, "Foo3.Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreField ignores deeply embedded field: Foo3.Alpha",
+	}, {
+		label:     "IgnoreFields",
+		x:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 5}}}},
+		y:         Bar1{Foo3{&Foo2{&Foo1{Alpha: 6}}}},
+		opts:      []cmp.Option{IgnoreFields(Bar1{}, "Foo3.Foo2.Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreField ignores deeply embedded field: Foo3.Foo2.Alpha",
+	}, {
+		label:     "IgnoreFields",
+		x:         createBar3X(),
+		y:         createBar3Y(),
+		wantEqual: false,
+		reason:    "not equal because many deeply nested or embedded fields differ",
+	}, {
+		label:     "IgnoreFields",
+		x:         createBar3X(),
+		y:         createBar3Y(),
+		opts:      []cmp.Option{IgnoreFields(Bar3{}, "Bar1", "Bravo", "Delta", "Foo3", "Alpha")},
+		wantEqual: true,
+		reason:    "equal because IgnoreFields ignores fields at the highest levels",
+	}, {
+		label: "IgnoreFields",
+		x:     createBar3X(),
+		y:     createBar3Y(),
+		opts: []cmp.Option{
+			IgnoreFields(Bar3{},
+				"Bar1.Foo3.Bravo",
+				"Bravo.Bar1.Foo3.Foo2.Foo1.Charlie",
+				"Bravo.Foo3.Foo2.Foo1.Bravo",
+				"Bravo.Bravo",
+				"Delta.Echo.Charlie",
+				"Foo3.Foo2.Foo1.Alpha",
+				"Alpha",
+			),
+		},
+		wantEqual: true,
+		reason:    "equal because IgnoreFields ignores fields using fully-qualified field",
+	}, {
+		label: "IgnoreFields",
+		x:     createBar3X(),
+		y:     createBar3Y(),
+		opts: []cmp.Option{
+			IgnoreFields(Bar3{},
+				"Bar1.Foo3.Bravo",
+				"Bravo.Foo3.Foo2.Foo1.Bravo",
+				"Bravo.Bravo",
+				"Delta.Echo.Charlie",
+				"Foo3.Foo2.Foo1.Alpha",
+				"Alpha",
+			),
+		},
+		wantEqual: false,
+		reason:    "not equal because one fully-qualified field is not ignored: Bravo.Bar1.Foo3.Foo2.Foo1.Charlie",
+	}, {
+		label:     "IgnoreFields",
+		x:         createBar3X(),
+		y:         createBar3Y(),
+		opts:      []cmp.Option{IgnoreFields(Bar3{}, "Bar1", "Bravo", "Delta", "Alpha")},
+		wantEqual: false,
+		reason:    "not equal because highest-level field is not ignored: Foo3",
+	}, {
+		label:     "IgnoreTypes",
+		x:         []interface{}{5, "same"},
+		y:         []interface{}{6, "same"},
+		wantEqual: false,
+		reason:    "not equal because 5 != 6",
+	}, {
+		label:     "IgnoreTypes",
+		x:         []interface{}{5, "same"},
+		y:         []interface{}{6, "same"},
+		opts:      []cmp.Option{IgnoreTypes(0)},
+		wantEqual: true,
+		reason:    "equal because ints are ignored",
+	}, {
+		label:     "IgnoreTypes+IgnoreInterfaces",
+		x:         []interface{}{5, "same", new(bytes.Buffer)},
+		y:         []interface{}{6, "same", new(bytes.Buffer)},
+		opts:      []cmp.Option{IgnoreTypes(0)},
+		wantPanic: true,
+		reason:    "panics because bytes.Buffer has unexported fields",
+	}, {
+		label: "IgnoreTypes+IgnoreInterfaces",
+		x:     []interface{}{5, "same", new(bytes.Buffer)},
+		y:     []interface{}{6, "diff", new(bytes.Buffer)},
+		opts: []cmp.Option{
+			IgnoreTypes(0, ""),
+			IgnoreInterfaces(struct{ io.Reader }{}),
+		},
+		wantEqual: true,
+		reason:    "equal because bytes.Buffer is ignored by match on interface type",
+	}, {
+		label: "IgnoreTypes+IgnoreInterfaces",
+		x:     []interface{}{5, "same", new(bytes.Buffer)},
+		y:     []interface{}{6, "same", new(bytes.Buffer)},
+		opts: []cmp.Option{
+			IgnoreTypes(0, ""),
+			IgnoreInterfaces(struct {
+				io.Reader
+				io.Writer
+				fmt.Stringer
+			}{}),
+		},
+		wantEqual: true,
+		reason:    "equal because bytes.Buffer is ignored by match on multiple interface types",
+	}, {
+		label:     "IgnoreInterfaces",
+		x:         struct{ mu sync.Mutex }{},
+		y:         struct{ mu sync.Mutex }{},
+		wantPanic: true,
+		reason:    "panics because sync.Mutex has unexported fields",
+	}, {
+		label:     "IgnoreInterfaces",
+		x:         struct{ mu sync.Mutex }{},
+		y:         struct{ mu sync.Mutex }{},
+		opts:      []cmp.Option{IgnoreInterfaces(struct{ sync.Locker }{})},
+		wantEqual: true,
+		reason:    "equal because IgnoreInterfaces applies on values (with pointer receiver)",
+	}, {
+		label:     "IgnoreInterfaces",
+		x:         struct{ mu *sync.Mutex }{},
+		y:         struct{ mu *sync.Mutex }{},
+		opts:      []cmp.Option{IgnoreInterfaces(struct{ sync.Locker }{})},
+		wantEqual: true,
+		reason:    "equal because IgnoreInterfaces applies on pointers",
+	}, {
+		label:     "IgnoreUnexported",
+		x:         ParentStruct{Public: 1, private: 2},
+		y:         ParentStruct{Public: 1, private: -2},
+		opts:      []cmp.Option{cmp.AllowUnexported(ParentStruct{})},
+		wantEqual: false,
+		reason:    "not equal because ParentStruct.private differs with AllowUnexported",
+	}, {
+		label:     "IgnoreUnexported",
+		x:         ParentStruct{Public: 1, private: 2},
+		y:         ParentStruct{Public: 1, private: -2},
+		opts:      []cmp.Option{IgnoreUnexported(ParentStruct{})},
+		wantEqual: true,
+		reason:    "equal because IgnoreUnexported ignored ParentStruct.private",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, PublicStruct: &PublicStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: -2, PublicStruct: &PublicStruct{Public: 3, private: 4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(PublicStruct{}),
+			IgnoreUnexported(ParentStruct{}),
+		},
+		wantEqual: true,
+		reason:    "equal because ParentStruct.private is ignored",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, PublicStruct: &PublicStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: -2, PublicStruct: &PublicStruct{Public: 3, private: -4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(PublicStruct{}),
+			IgnoreUnexported(ParentStruct{}),
+		},
+		wantEqual: false,
+		reason:    "not equal because ParentStruct.PublicStruct.private differs and not ignored by IgnoreUnexported(ParentStruct{})",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, PublicStruct: &PublicStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: -2, PublicStruct: &PublicStruct{Public: 3, private: -4}},
+		opts: []cmp.Option{
+			IgnoreUnexported(ParentStruct{}, PublicStruct{}),
+		},
+		wantEqual: true,
+		reason:    "equal because both ParentStruct.PublicStruct and ParentStruct.PublicStruct.private are ignored",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: -3, private: -4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(privateStruct{}, PublicStruct{}, ParentStruct{}),
+		},
+		wantEqual: false,
+		reason:    "not equal since ParentStruct.privateStruct differs",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: -3, private: -4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(privateStruct{}, PublicStruct{}),
+			IgnoreUnexported(ParentStruct{}),
+		},
+		wantEqual: true,
+		reason:    "equal because ParentStruct.privateStruct ignored by IgnoreUnexported(ParentStruct{})",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: 3, private: -4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(PublicStruct{}, ParentStruct{}),
+			IgnoreUnexported(privateStruct{}),
+		},
+		wantEqual: true,
+		reason:    "equal because privateStruct.private ignored by IgnoreUnexported(privateStruct{})",
+	}, {
+		label: "IgnoreUnexported",
+		x:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: 3, private: 4}},
+		y:     ParentStruct{Public: 1, private: 2, privateStruct: &privateStruct{Public: -3, private: -4}},
+		opts: []cmp.Option{
+			cmp.AllowUnexported(PublicStruct{}, ParentStruct{}),
+			IgnoreUnexported(privateStruct{}),
+		},
+		wantEqual: false,
+		reason:    "not equal because privateStruct.Public differs and not ignored by IgnoreUnexported(privateStruct{})",
+	}, {
+		label: "IgnoreFields+IgnoreTypes+IgnoreUnexported",
+		x: &Everything{
+			MyInt:   5,
+			MyFloat: 3.3,
+			MyTime:  MyTime{time.Now()},
+			Bar3:    *createBar3X(),
+			ParentStruct: ParentStruct{
+				Public: 1, private: 2, PublicStruct: &PublicStruct{Public: 3, private: 4},
+			},
+		},
+		y: &Everything{
+			MyInt:   -5,
+			MyFloat: 3.3,
+			MyTime:  MyTime{time.Now()},
+			Bar3:    *createBar3Y(),
+			ParentStruct: ParentStruct{
+				Public: 1, private: -2, PublicStruct: &PublicStruct{Public: -3, private: -4},
+			},
+		},
+		opts: []cmp.Option{
+			IgnoreFields(Everything{}, "MyTime", "Bar3.Foo3"),
+			IgnoreFields(Bar3{}, "Bar1", "Bravo", "Delta", "Alpha"),
+			IgnoreTypes(MyInt(0), PublicStruct{}),
+			IgnoreUnexported(ParentStruct{}),
+		},
+		wantEqual: true,
+		reason:    "equal because all Ignore options can be composed together",
+	}}
+
+	for _, tt := range tests {
+		tRun(t, tt.label, func(t *testing.T) {
+			var gotEqual bool
+			var gotPanic string
+			func() {
+				defer func() {
+					if ex := recover(); ex != nil {
+						gotPanic = fmt.Sprint(ex)
+					}
+				}()
+				gotEqual = cmp.Equal(tt.x, tt.y, tt.opts...)
+			}()
+			switch {
+			case gotPanic == "" && tt.wantPanic:
+				t.Errorf("expected Equal panic\nreason: %s", tt.reason)
+			case gotPanic != "" && !tt.wantPanic:
+				t.Errorf("unexpected Equal panic: got %v\nreason: %v", gotPanic, tt.reason)
+			case gotEqual != tt.wantEqual:
+				t.Errorf("Equal = %v, want %v\nreason: %v", gotEqual, tt.wantEqual, tt.reason)
+			}
+		})
+	}
+}
+
+func TestPanic(t *testing.T) {
+	args := func(x ...interface{}) []interface{} { return x }
+	tests := []struct {
+		label     string        // Test name
+		fnc       interface{}   // Option function to call
+		args      []interface{} // Arguments to pass in
+		wantPanic string        // Expected panic message
+		reason    string        // The reason for the expected outcome
+	}{{
+		label:  "EquateApprox",
+		fnc:    EquateApprox,
+		args:   args(0.0, 0.0),
+		reason: "zero margin and fraction is equivalent to exact equality",
+	}, {
+		label:     "EquateApprox",
+		fnc:       EquateApprox,
+		args:      args(-0.1, 0.0),
+		wantPanic: "margin or fraction must be a non-negative number",
+		reason:    "negative inputs are invalid",
+	}, {
+		label:     "EquateApprox",
+		fnc:       EquateApprox,
+		args:      args(0.0, -0.1),
+		wantPanic: "margin or fraction must be a non-negative number",
+		reason:    "negative inputs are invalid",
+	}, {
+		label:     "EquateApprox",
+		fnc:       EquateApprox,
+		args:      args(math.NaN(), 0.0),
+		wantPanic: "margin or fraction must be a non-negative number",
+		reason:    "NaN inputs are invalid",
+	}, {
+		label:  "EquateApprox",
+		fnc:    EquateApprox,
+		args:   args(1.0, 0.0),
+		reason: "fraction of 1.0 or greater is valid",
+	}, {
+		label:  "EquateApprox",
+		fnc:    EquateApprox,
+		args:   args(0.0, math.Inf(+1)),
+		reason: "margin of infinity is valid",
+	}, {
+		label:     "SortSlices",
+		fnc:       SortSlices,
+		args:      args(strings.Compare),
+		wantPanic: "invalid less function",
+		reason:    "func(x, y string) int is wrong signature for less",
+	}, {
+		label:     "SortSlices",
+		fnc:       SortSlices,
+		args:      args((func(_, _ int) bool)(nil)),
+		wantPanic: "invalid less function",
+		reason:    "nil value is not valid",
+	}, {
+		label:     "SortMaps",
+		fnc:       SortMaps,
+		args:      args(strings.Compare),
+		wantPanic: "invalid less function",
+		reason:    "func(x, y string) int is wrong signature for less",
+	}, {
+		label:     "SortMaps",
+		fnc:       SortMaps,
+		args:      args((func(_, _ int) bool)(nil)),
+		wantPanic: "invalid less function",
+		reason:    "nil value is not valid",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, ""),
+		wantPanic: "name must not be empty",
+		reason:    "empty selector is invalid",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "."),
+		wantPanic: "name must not be empty",
+		reason:    "single dot selector is invalid",
+	}, {
+		label:  "IgnoreFields",
+		fnc:    IgnoreFields,
+		args:   args(Foo1{}, ".Alpha"),
+		reason: "dot-prefix is okay since Foo1.Alpha reads naturally",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "Alpha."),
+		wantPanic: "name must not be empty",
+		reason:    "dot-suffix is invalid",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "Alpha "),
+		wantPanic: "does not exist",
+		reason:    "identifiers must not have spaces",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "Zulu"),
+		wantPanic: "does not exist",
+		reason:    "name of non-existent field is invalid",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "Alpha.NoExist"),
+		wantPanic: "must be a struct",
+		reason:    "cannot select into a non-struct",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(&Foo1{}, "Alpha"),
+		wantPanic: "must be a struct",
+		reason:    "the type must be a struct (not pointer to a struct)",
+	}, {
+		label:     "IgnoreFields",
+		fnc:       IgnoreFields,
+		args:      args(Foo1{}, "unexported"),
+		wantPanic: "name must be exported",
+		reason:    "unexported fields must not be specified",
+	}, {
+		label:  "IgnoreTypes",
+		fnc:    IgnoreTypes,
+		reason: "empty input is valid",
+	}, {
+		label:     "IgnoreTypes",
+		fnc:       IgnoreTypes,
+		args:      args(nil),
+		wantPanic: "cannot determine type",
+		reason:    "input must not be nil value",
+	}, {
+		label:  "IgnoreTypes",
+		fnc:    IgnoreTypes,
+		args:   args(0, 0, 0),
+		reason: "duplicate inputs of the same type is valid",
+	}, {
+		label:     "IgnoreInterfaces",
+		fnc:       IgnoreInterfaces,
+		args:      args(nil),
+		wantPanic: "input must be an anonymous struct",
+		reason:    "input must not be nil value",
+	}, {
+		label:     "IgnoreInterfaces",
+		fnc:       IgnoreInterfaces,
+		args:      args(Foo1{}),
+		wantPanic: "input must be an anonymous struct",
+		reason:    "input must not be a named struct type",
+	}, {
+		label:     "IgnoreInterfaces",
+		fnc:       IgnoreInterfaces,
+		args:      args(struct{ _ io.Reader }{}),
+		wantPanic: "struct cannot have named fields",
+		reason:    "input must not have named fields",
+	}, {
+		label:     "IgnoreInterfaces",
+		fnc:       IgnoreInterfaces,
+		args:      args(struct{ Foo1 }{}),
+		wantPanic: "embedded field must be an interface type",
+		reason:    "field types must be interfaces",
+	}, {
+		label:     "IgnoreInterfaces",
+		fnc:       IgnoreInterfaces,
+		args:      args(struct{ EmptyInterface }{}),
+		wantPanic: "cannot ignore empty interface",
+		reason:    "field types must not be the empty interface",
+	}, {
+		label: "IgnoreInterfaces",
+		fnc:   IgnoreInterfaces,
+		args: args(struct {
+			io.Reader
+			io.Writer
+			io.Closer
+			io.ReadWriteCloser
+		}{}),
+		reason: "multiple interfaces may be specified, even if they overlap",
+	}, {
+		label:  "IgnoreUnexported",
+		fnc:    IgnoreUnexported,
+		reason: "empty input is valid",
+	}, {
+		label:     "IgnoreUnexported",
+		fnc:       IgnoreUnexported,
+		args:      args(nil),
+		wantPanic: "invalid struct type",
+		reason:    "input must not be nil value",
+	}, {
+		label:     "IgnoreUnexported",
+		fnc:       IgnoreUnexported,
+		args:      args(&Foo1{}),
+		wantPanic: "invalid struct type",
+		reason:    "input must be a struct type (not a pointer to a struct)",
+	}, {
+		label:  "IgnoreUnexported",
+		fnc:    IgnoreUnexported,
+		args:   args(Foo1{}, struct{ x, X int }{}),
+		reason: "input may be named or unnamed structs",
+	}}
+
+	for _, tt := range tests {
+		tRun(t, tt.label, func(t *testing.T) {
+			// Prepare function arguments.
+			vf := reflect.ValueOf(tt.fnc)
+			var vargs []reflect.Value
+			for i, arg := range tt.args {
+				if arg == nil {
+					tf := vf.Type()
+					if i == tf.NumIn()-1 && tf.IsVariadic() {
+						vargs = append(vargs, reflect.Zero(tf.In(i).Elem()))
+					} else {
+						vargs = append(vargs, reflect.Zero(tf.In(i)))
+					}
+				} else {
+					vargs = append(vargs, reflect.ValueOf(arg))
+				}
+			}
+
+			// Call the function and capture any panics.
+			var gotPanic string
+			func() {
+				defer func() {
+					if ex := recover(); ex != nil {
+						if s, ok := ex.(string); ok {
+							gotPanic = s
+						} else {
+							panic(ex)
+						}
+					}
+				}()
+				vf.Call(vargs)
+			}()
+
+			switch {
+			case tt.wantPanic == "" && gotPanic != "":
+				t.Errorf("unexpected panic message: %s\nreason: %s", gotPanic, tt.reason)
+			case tt.wantPanic != "" && !strings.Contains(gotPanic, tt.wantPanic):
+				t.Errorf("panic message:\ngot:  %s\nwant: %s\nreason: %s", gotPanic, tt.wantPanic, tt.reason)
+			}
+		})
+	}
+}
+
+// TODO: Delete this hack when we drop Go1.6 support.
+func tRun(t *testing.T, name string, f func(t *testing.T)) {
+	type runner interface {
+		Run(string, func(t *testing.T)) bool
+	}
+	var ti interface{} = t
+	if r, ok := ti.(runner); ok {
+		r.Run(name, f)
+	} else {
+		t.Logf("Test: %s", name)
+		f(t)
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/compare.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare.go
@@ -1,0 +1,517 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// Package cmp determines equality of values.
+//
+// This package is intended to be a more powerful and safer alternative to
+// reflect.DeepEqual for comparing whether two values are semantically equal.
+//
+// The primary features of cmp are:
+//
+// • When the default behavior of equality does not suit the needs of the test,
+// custom equality functions can override the equality operation.
+// For example, an equality function may report floats as equal so long as they
+// are within some tolerance of each other.
+//
+// • Types that have an Equal method may use that method to determine equality.
+// This allows package authors to determine the equality operation for the types
+// that they define.
+//
+// • If no custom equality functions are used and no Equal method is defined,
+// equality is determined by recursively comparing the primitive kinds on both
+// values, much like reflect.DeepEqual. Unlike reflect.DeepEqual, unexported
+// fields are not compared; they result in panics unless suppressed by using
+// an Ignore option.
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// BUG: Maps with keys containing NaN values cannot be properly compared due to
+// the reflection package's inability to retrieve such entries. Equal will panic
+// anytime it comes across a NaN key, but this behavior may change.
+//
+// See https://golang.org/issue/11104 for more details.
+
+// Equal reports whether x and y are equal by recursively applying the
+// following rules in the given order to x and y and all of their sub-values:
+//
+// • If two values are not of the same type, then they are never equal
+// and the overall result is false.
+//
+// • Let S be the set of all Ignore, Transformer, and Comparer options that
+// remain after applying all path filters, value filters, and type filters.
+// If at least one Ignore exists in S, then the comparison is ignored.
+// If the number of Transformer and Comparer options in S is greater than one,
+// then Equal panics because it is ambiguous which option to use.
+// If S contains a single Transformer, then apply that transformer on the
+// current values and recursively call Equal on the transformed output values.
+// If S contains a single Comparer, then use that Comparer to determine whether
+// the current values are equal or not.
+// Otherwise, S is empty and evaluation proceeds to the next rule.
+//
+// • If the values have an Equal method of the form "(T) Equal(T) bool" or
+// "(T) Equal(I) bool" where T is assignable to I, then use the result of
+// x.Equal(y). Otherwise, no such method exists and evaluation proceeds to
+// the next rule.
+//
+// • Lastly, try to compare x and y based on their basic kinds.
+// Simple kinds like booleans, integers, floats, complex numbers, strings, and
+// channels are compared using the equivalent of the == operator in Go.
+// Functions are only equal if they are both nil, otherwise they are unequal.
+// Pointers are equal if the underlying values they point to are also equal.
+// Interfaces are equal if their underlying concrete values are also equal.
+//
+// Structs are equal if all of their fields are equal. If a struct contains
+// unexported fields, Equal panics unless the AllowUnexported option is used or
+// an Ignore option (e.g., cmpopts.IgnoreUnexported) ignores that field.
+// Slices and arrays are equal if they have the same length and the elements
+// at each index are equal.
+// Maps are equal if their keys are exactly equal (according to the == operator)
+// and the corresponding elements for each key are equal. To specify a custom
+// comparison for map keys, use a Transformer to convert the map to a
+// corresponding slice type.
+func Equal(x, y interface{}, opts ...Option) bool {
+	s := newState(opts)
+	s.compareAny(reflect.ValueOf(x), reflect.ValueOf(y))
+	return s.eq
+}
+
+// Diff returns a human-readable report of the differences between two values.
+// It returns an empty string if and only if Equal returns true for the same
+// input values and options. The output string will use the "-" symbol to
+// indicate elements removed from x, and the "+" symbol to indicate elements
+// added to y.
+//
+// Do not depend on this output being stable.
+func Diff(x, y interface{}, opts ...Option) string {
+	r := new(defaultReporter)
+	opts = append(opts[:len(opts):len(opts)], r) // Force copy when appending
+	eq := Equal(x, y, opts...)
+	d := r.String()
+	if (d == "") != eq {
+		panic("inconsistent difference and equality results")
+	}
+	return d
+}
+
+type state struct {
+	eq      bool // Current result of comparison
+	curPath Path // The current path in the value tree
+
+	// dsCheck tracks the state needed to periodically perform checks that
+	// user provided func(T, T) bool functions are symmetric and deterministic.
+	//
+	// Checks occur every Nth function call, where N is a triangular number:
+	//	0 1 3 6 10 15 21 28 36 45 55 66 78 91 105 120 136 153 171 190 ...
+	// See https://en.wikipedia.org/wiki/Triangular_number
+	//
+	// This sequence ensures that the cost of checks drops significantly as
+	// the number of functions calls grows larger.
+	dsCheck struct{ curr, next int }
+
+	// These fields, once set by processOption, will not change.
+	exporters map[reflect.Type]bool // Set of structs with unexported field visibility
+	optsIgn   []option              // List of all ignore options without value filters
+	opts      []option              // List of all other options
+	reporter  reporter              // Optional reporter used for difference formatting
+}
+
+func newState(opts []Option) *state {
+	s := &state{eq: true}
+	for _, opt := range opts {
+		s.processOption(opt)
+	}
+	// Move Ignore options to the front so that they are evaluated first.
+	for i, j := 0, 0; i < len(s.opts); i++ {
+		if s.opts[i].op == nil {
+			s.opts[i], s.opts[j] = s.opts[j], s.opts[i]
+			j++
+		}
+	}
+	return s
+}
+
+func (s *state) processOption(opt Option) {
+	switch opt := opt.(type) {
+	case Options:
+		for _, o := range opt {
+			s.processOption(o)
+		}
+	case visibleStructs:
+		if s.exporters == nil {
+			s.exporters = make(map[reflect.Type]bool)
+		}
+		for t := range opt {
+			s.exporters[t] = true
+		}
+	case option:
+		if opt.typeFilter == nil && len(opt.pathFilters)+len(opt.valueFilters) == 0 {
+			panic(fmt.Sprintf("cannot use an unfiltered option: %v", opt))
+		}
+		if opt.op == nil && len(opt.valueFilters) == 0 {
+			s.optsIgn = append(s.optsIgn, opt)
+		} else {
+			s.opts = append(s.opts, opt)
+		}
+	case reporter:
+		if s.reporter != nil {
+			panic("difference reporter already registered")
+		}
+		s.reporter = opt
+	default:
+		panic(fmt.Sprintf("unknown option %T", opt))
+	}
+}
+
+func (s *state) compareAny(vx, vy reflect.Value) {
+	// TODO: Support cyclic data structures.
+
+	// Rule 0: Differing types are never equal.
+	if !vx.IsValid() || !vy.IsValid() {
+		s.report(vx.IsValid() == vy.IsValid(), vx, vy)
+		return
+	}
+	if vx.Type() != vy.Type() {
+		s.report(false, vx, vy) // Possible for path to be empty
+		return
+	}
+	t := vx.Type()
+	if len(s.curPath) == 0 {
+		s.curPath.push(&pathStep{typ: t})
+	}
+
+	// Rule 1: Check whether an option applies on this node in the value tree.
+	if s.tryOptions(&vx, &vy, t) {
+		return
+	}
+
+	// Rule 2: Check whether the type has a valid Equal method.
+	if s.tryMethod(vx, vy, t) {
+		return
+	}
+
+	// Rule 3: Recursively descend into each value's underlying kind.
+	switch t.Kind() {
+	case reflect.Bool:
+		s.report(vx.Bool() == vy.Bool(), vx, vy)
+		return
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		s.report(vx.Int() == vy.Int(), vx, vy)
+		return
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		s.report(vx.Uint() == vy.Uint(), vx, vy)
+		return
+	case reflect.Float32, reflect.Float64:
+		s.report(vx.Float() == vy.Float(), vx, vy)
+		return
+	case reflect.Complex64, reflect.Complex128:
+		s.report(vx.Complex() == vy.Complex(), vx, vy)
+		return
+	case reflect.String:
+		s.report(vx.String() == vy.String(), vx, vy)
+		return
+	case reflect.Chan, reflect.UnsafePointer:
+		s.report(vx.Pointer() == vy.Pointer(), vx, vy)
+		return
+	case reflect.Func:
+		s.report(vx.IsNil() && vy.IsNil(), vx, vy)
+		return
+	case reflect.Ptr:
+		if vx.IsNil() || vy.IsNil() {
+			s.report(vx.IsNil() && vy.IsNil(), vx, vy)
+			return
+		}
+		s.curPath.push(&indirect{pathStep{t.Elem()}})
+		defer s.curPath.pop()
+		s.compareAny(vx.Elem(), vy.Elem())
+		return
+	case reflect.Interface:
+		if vx.IsNil() || vy.IsNil() {
+			s.report(vx.IsNil() && vy.IsNil(), vx, vy)
+			return
+		}
+		if vx.Elem().Type() != vy.Elem().Type() {
+			s.report(false, vx.Elem(), vy.Elem())
+			return
+		}
+		s.curPath.push(&typeAssertion{pathStep{vx.Elem().Type()}})
+		defer s.curPath.pop()
+		s.compareAny(vx.Elem(), vy.Elem())
+		return
+	case reflect.Slice:
+		if vx.IsNil() || vy.IsNil() {
+			s.report(vx.IsNil() && vy.IsNil(), vx, vy)
+			return
+		}
+		fallthrough
+	case reflect.Array:
+		s.compareArray(vx, vy, t)
+		return
+	case reflect.Map:
+		s.compareMap(vx, vy, t)
+		return
+	case reflect.Struct:
+		s.compareStruct(vx, vy, t)
+		return
+	default:
+		panic(fmt.Sprintf("%v kind not handled", t.Kind()))
+	}
+}
+
+// tryOptions iterates through all of the options and evaluates whether any
+// of them can be applied. This may modify the underlying values vx and vy
+// if an unexported field is being forcibly exported.
+func (s *state) tryOptions(vx, vy *reflect.Value, t reflect.Type) bool {
+	// Try all ignore options that do not depend on the value first.
+	// This avoids possible panics when processing unexported fields.
+	for _, opt := range s.optsIgn {
+		var v reflect.Value // Dummy value; should never be used
+		if s.applyFilters(v, v, t, opt) {
+			return true // Ignore option applied
+		}
+	}
+
+	// Since the values must be used after this point, verify that the values
+	// are either exported or can be forcibly exported.
+	if sf, ok := s.curPath[len(s.curPath)-1].(*structField); ok && sf.unexported {
+		if !sf.force {
+			const help = "consider using AllowUnexported or cmpopts.IgnoreUnexported"
+			panic(fmt.Sprintf("cannot handle unexported field: %#v\n%s", s.curPath, help))
+		}
+
+		// Use unsafe pointer arithmetic to get read-write access to an
+		// unexported field in the struct.
+		*vx = unsafeRetrieveField(sf.pvx, sf.field)
+		*vy = unsafeRetrieveField(sf.pvy, sf.field)
+	}
+
+	// Try all other options now.
+	optIdx := -1 // Index of Option to apply
+	for i, opt := range s.opts {
+		if !s.applyFilters(*vx, *vy, t, opt) {
+			continue
+		}
+		if opt.op == nil {
+			return true // Ignored comparison
+		}
+		if optIdx >= 0 {
+			panic(fmt.Sprintf("ambiguous set of options at %#v\n\n%v\n\n%v\n", s.curPath, s.opts[optIdx], opt))
+		}
+		optIdx = i
+	}
+	if optIdx >= 0 {
+		s.applyOption(*vx, *vy, t, s.opts[optIdx])
+		return true
+	}
+	return false
+}
+
+func (s *state) applyFilters(vx, vy reflect.Value, t reflect.Type, opt option) bool {
+	if opt.typeFilter != nil {
+		if !t.AssignableTo(opt.typeFilter) {
+			return false
+		}
+	}
+	for _, f := range opt.pathFilters {
+		if !f(s.curPath) {
+			return false
+		}
+	}
+	for _, f := range opt.valueFilters {
+		if !t.AssignableTo(f.in) || !s.callFunc(f.fnc, vx, vy) {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *state) applyOption(vx, vy reflect.Value, t reflect.Type, opt option) {
+	switch op := opt.op.(type) {
+	case *transformer:
+		vx = op.fnc.Call([]reflect.Value{vx})[0]
+		vy = op.fnc.Call([]reflect.Value{vy})[0]
+		s.curPath.push(&transform{pathStep{op.fnc.Type().Out(0)}, op})
+		defer s.curPath.pop()
+		s.compareAny(vx, vy)
+		return
+	case *comparer:
+		eq := s.callFunc(op.fnc, vx, vy)
+		s.report(eq, vx, vy)
+		return
+	}
+}
+
+func (s *state) tryMethod(vx, vy reflect.Value, t reflect.Type) bool {
+	// Check if this type even has an Equal method.
+	m, ok := t.MethodByName("Equal")
+	ft := functionType(m.Type)
+	if !ok || (ft != equalFunc && ft != equalIfaceFunc) {
+		return false
+	}
+
+	eq := s.callFunc(m.Func, vx, vy)
+	s.report(eq, vx, vy)
+	return true
+}
+
+func (s *state) callFunc(f, x, y reflect.Value) bool {
+	got := f.Call([]reflect.Value{x, y})[0].Bool()
+	if s.dsCheck.curr == s.dsCheck.next {
+		// Swapping the input arguments is sufficient to check that
+		// f is symmetric and deterministic.
+		want := f.Call([]reflect.Value{y, x})[0].Bool()
+		if got != want {
+			fn := getFuncName(f.Pointer())
+			panic(fmt.Sprintf("non-deterministic or non-symmetric function detected: %s", fn))
+		}
+		s.dsCheck.curr = 0
+		s.dsCheck.next++
+	}
+	s.dsCheck.curr++
+	return got
+}
+
+func (s *state) compareArray(vx, vy reflect.Value, t reflect.Type) {
+	step := &sliceIndex{pathStep{t.Elem()}, 0}
+	s.curPath.push(step)
+	defer s.curPath.pop()
+
+	// Regardless of the lengths, we always try to compare the elements.
+	// If one slice is longer, we will report the elements of the longer
+	// slice as different (relative to an invalid reflect.Value).
+	nmin := vx.Len()
+	if nmin > vy.Len() {
+		nmin = vy.Len()
+	}
+	for i := 0; i < nmin; i++ {
+		step.key = i
+		s.compareAny(vx.Index(i), vy.Index(i))
+	}
+	for i := nmin; i < vx.Len(); i++ {
+		step.key = i
+		s.report(false, vx.Index(i), reflect.Value{})
+	}
+	for i := nmin; i < vy.Len(); i++ {
+		step.key = i
+		s.report(false, reflect.Value{}, vy.Index(i))
+	}
+}
+
+func (s *state) compareMap(vx, vy reflect.Value, t reflect.Type) {
+	if vx.IsNil() || vy.IsNil() {
+		s.report(vx.IsNil() && vy.IsNil(), vx, vy)
+		return
+	}
+
+	// We combine and sort the two map keys so that we can perform the
+	// comparisons in a deterministic order.
+	step := &mapIndex{pathStep: pathStep{t.Elem()}}
+	s.curPath.push(step)
+	defer s.curPath.pop()
+	for _, k := range sortKeys(append(vx.MapKeys(), vy.MapKeys()...)) {
+		step.key = k
+		vvx := vx.MapIndex(k)
+		vvy := vy.MapIndex(k)
+		switch {
+		case vvx.IsValid() && vvy.IsValid():
+			s.compareAny(vvx, vvy)
+		case vvx.IsValid() && !vvy.IsValid():
+			s.report(false, vvx, reflect.Value{})
+		case !vvx.IsValid() && vvy.IsValid():
+			s.report(false, reflect.Value{}, vvy)
+		default:
+			// It is possible for both vvx and vvy to be invalid if the
+			// key contained a NaN value in it. There is no way in
+			// reflection to be able to retrieve these values.
+			// See https://golang.org/issue/11104
+			panic(fmt.Sprintf("%#v has map key with NaNs", s.curPath))
+		}
+	}
+}
+
+func (s *state) compareStruct(vx, vy reflect.Value, t reflect.Type) {
+	var vax, vay reflect.Value // Addressable versions of vx and vy
+
+	step := &structField{}
+	s.curPath.push(step)
+	defer s.curPath.pop()
+	for i := 0; i < t.NumField(); i++ {
+		vvx := vx.Field(i)
+		vvy := vy.Field(i)
+		step.typ = t.Field(i).Type
+		step.name = t.Field(i).Name
+		step.idx = i
+		step.unexported = !isExported(step.name)
+		if step.unexported {
+			// Defer checking of unexported fields until later to give an
+			// Ignore a chance to ignore the field.
+			if !vax.IsValid() || !vay.IsValid() {
+				// For unsafeRetrieveField to work, the parent struct must
+				// be addressable. Create a new copy of the values if
+				// necessary to make them addressable.
+				vax = makeAddressable(vx)
+				vay = makeAddressable(vy)
+			}
+			step.force = s.exporters[t]
+			step.pvx = vax
+			step.pvy = vay
+			step.field = t.Field(i)
+		}
+		s.compareAny(vvx, vvy)
+	}
+}
+
+// report records the result of a single comparison.
+// It also calls Report if any reporter is registered.
+func (s *state) report(eq bool, vx, vy reflect.Value) {
+	s.eq = s.eq && eq
+	if s.reporter != nil {
+		s.reporter.Report(vx, vy, eq, s.curPath)
+	}
+}
+
+// makeAddressable returns a value that is always addressable.
+// It returns the input verbatim if it is already addressable,
+// otherwise it creates a new value and returns an addressable copy.
+func makeAddressable(v reflect.Value) reflect.Value {
+	if v.CanAddr() {
+		return v
+	}
+	vc := reflect.New(v.Type()).Elem()
+	vc.Set(v)
+	return vc
+}
+
+type funcType int
+
+const (
+	invalidFunc     funcType    = iota
+	equalFunc                   // func(T, T) bool
+	equalIfaceFunc              // func(T, I) bool
+	transformFunc               // func(T) R
+	valueFilterFunc = equalFunc // func(T, T) bool
+)
+
+var boolType = reflect.TypeOf(true)
+
+// functionType identifies which type of function signature this is.
+func functionType(t reflect.Type) funcType {
+	if t == nil || t.Kind() != reflect.Func || t.IsVariadic() {
+		return invalidFunc
+	}
+	ni, no := t.NumIn(), t.NumOut()
+	switch {
+	case ni == 2 && no == 1 && t.In(0) == t.In(1) && t.Out(0) == boolType:
+		return equalFunc // or valueFilterFunc
+	case ni == 2 && no == 1 && t.In(0).AssignableTo(t.In(1)) && t.Out(0) == boolType:
+		return equalIfaceFunc
+	case ni == 1 && no == 1:
+		return transformFunc
+	default:
+		return invalidFunc
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/compare_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/compare_test.go
@@ -1,0 +1,1775 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/rand"
+	"reflect"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/google/go-cmp/cmp"
+	pb "github.com/google/go-cmp/cmp/internal/testprotos"
+	ts "github.com/google/go-cmp/cmp/internal/teststructs"
+)
+
+var now = time.Now()
+var boolType = reflect.TypeOf(true)
+var mutexType = reflect.TypeOf(sync.Mutex{})
+
+func intPtr(n int) *int { return &n }
+
+func equalRegexp(x, y *regexp.Regexp) bool {
+	if x == nil || y == nil {
+		return x == nil && y == nil
+	}
+	return x.String() == y.String()
+}
+
+func IgnoreUnexported(typs ...interface{}) cmp.Option {
+	m := make(map[reflect.Type]bool)
+	for _, typ := range typs {
+		t := reflect.TypeOf(typ)
+		if t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("invalid struct type: %T", typ))
+		}
+		m[t] = true
+	}
+	return cmp.FilterPath(func(p cmp.Path) bool {
+		if len(p) < 2 {
+			return false
+		}
+		sf, ok := p[len(p)-1].(cmp.StructField)
+		if !ok {
+			return false
+		}
+		return m[p[len(p)-2].Type()] && !isExported(sf.Name())
+	}, cmp.Ignore())
+}
+
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+type test struct {
+	label     string       // Test description
+	x, y      interface{}  // Input values to compare
+	opts      []cmp.Option // Input options
+	wantDiff  string       // The exact difference string
+	wantPanic string       // Sub-string of an expected panic message
+}
+
+func TestDiff(t *testing.T) {
+	var tests []test
+	tests = append(tests, comparerTests()...)
+	tests = append(tests, transformerTests()...)
+	tests = append(tests, embeddedTests()...)
+	tests = append(tests, methodTests()...)
+	tests = append(tests, project1Tests()...)
+	tests = append(tests, project2Tests()...)
+	tests = append(tests, project3Tests()...)
+	tests = append(tests, project4Tests()...)
+
+	for _, tt := range tests {
+		tRun(t, tt.label, func(t *testing.T) {
+			var gotDiff, gotPanic string
+			func() {
+				defer func() {
+					if ex := recover(); ex != nil {
+						if s, ok := ex.(string); ok {
+							gotPanic = s
+						} else {
+							panic(ex)
+						}
+					}
+				}()
+				gotDiff = cmp.Diff(tt.x, tt.y, tt.opts...)
+			}()
+			if tt.wantPanic == "" {
+				if gotPanic != "" {
+					t.Fatalf("unexpected panic message: %s", gotPanic)
+				}
+				if strings.TrimSpace(gotDiff) != strings.TrimSpace(tt.wantDiff) {
+					t.Fatalf("difference message:\ngot:\n%s\nwant:\n%s", gotDiff, tt.wantDiff)
+				}
+			} else {
+				if !strings.Contains(gotPanic, tt.wantPanic) {
+					t.Fatalf("panic message:\ngot:  %s\nwant: %s", gotPanic, tt.wantPanic)
+				}
+			}
+		})
+	}
+}
+
+func comparerTests() []test {
+	const label = "Comparer"
+
+	return []test{{
+		label:    label,
+		x:        1,
+		y:        1,
+		wantDiff: "",
+	}, {
+		label:     label,
+		x:         1,
+		y:         1,
+		opts:      []cmp.Option{cmp.Ignore()},
+		wantPanic: "cannot use an unfiltered option",
+	}, {
+		label:     label,
+		x:         1,
+		y:         1,
+		opts:      []cmp.Option{cmp.Comparer(func(_, _ interface{}) bool { return true })},
+		wantPanic: "cannot use an unfiltered option",
+	}, {
+		label:     label,
+		x:         1,
+		y:         1,
+		opts:      []cmp.Option{cmp.Transformer("", func(x interface{}) interface{} { return x })},
+		wantPanic: "cannot use an unfiltered option",
+	}, {
+		label: label,
+		x:     1,
+		y:     1,
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y int) bool { return true }),
+			cmp.Transformer("", func(x int) float64 { return float64(x) }),
+		},
+		wantPanic: "ambiguous set of options",
+	}, {
+		label: label,
+		x:     1,
+		y:     1,
+		opts: []cmp.Option{
+			cmp.FilterPath(func(p cmp.Path) bool {
+				return len(p) > 0 && p[len(p)-1].Type().Kind() == reflect.Int
+			}, cmp.Options{cmp.Ignore(), cmp.Ignore(), cmp.Ignore()}),
+			cmp.Comparer(func(x, y int) bool { return true }),
+			cmp.Transformer("", func(x int) float64 { return float64(x) }),
+		},
+	}, {
+		label:     label,
+		opts:      []cmp.Option{struct{ cmp.Option }{}},
+		wantPanic: "unknown option",
+	}, {
+		label:    label,
+		x:        struct{ A, B, C int }{1, 2, 3},
+		y:        struct{ A, B, C int }{1, 2, 3},
+		wantDiff: "",
+	}, {
+		label:    label,
+		x:        struct{ A, B, C int }{1, 2, 3},
+		y:        struct{ A, B, C int }{1, 2, 4},
+		wantDiff: "root.C:\n\t-: 3\n\t+: 4\n",
+	}, {
+		label:     label,
+		x:         struct{ a, b, c int }{1, 2, 3},
+		y:         struct{ a, b, c int }{1, 2, 4},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     &struct{ A *int }{intPtr(4)},
+		y:     &struct{ A *int }{intPtr(4)},
+	}, {
+		label:    label,
+		x:        &struct{ A *int }{intPtr(4)},
+		y:        &struct{ A *int }{intPtr(5)},
+		wantDiff: "*root.A:\n\t-: 4\n\t+: 5\n",
+	}, {
+		label: label,
+		x:     &struct{ A *int }{intPtr(4)},
+		y:     &struct{ A *int }{intPtr(5)},
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y int) bool { return true }),
+		},
+	}, {
+		label: label,
+		x:     &struct{ A *int }{intPtr(4)},
+		y:     &struct{ A *int }{intPtr(5)},
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y *int) bool { return x != nil && y != nil }),
+		},
+	}, {
+		label: label,
+		x:     &struct{ R *bytes.Buffer }{},
+		y:     &struct{ R *bytes.Buffer }{},
+	}, {
+		label:    label,
+		x:        &struct{ R *bytes.Buffer }{new(bytes.Buffer)},
+		y:        &struct{ R *bytes.Buffer }{},
+		wantDiff: "root.R:\n\t-: \"\"\n\t+: <nil>\n",
+	}, {
+		label: label,
+		x:     &struct{ R *bytes.Buffer }{new(bytes.Buffer)},
+		y:     &struct{ R *bytes.Buffer }{},
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y io.Reader) bool { return true }),
+		},
+	}, {
+		label:     label,
+		x:         &struct{ R bytes.Buffer }{},
+		y:         &struct{ R bytes.Buffer }{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     &struct{ R bytes.Buffer }{},
+		y:     &struct{ R bytes.Buffer }{},
+		opts: []cmp.Option{
+			cmp.Comparer(func(x, y io.Reader) bool { return true }),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     &struct{ R bytes.Buffer }{},
+		y:     &struct{ R bytes.Buffer }{},
+		opts: []cmp.Option{
+			cmp.Transformer("Ref", func(x bytes.Buffer) *bytes.Buffer { return &x }),
+			cmp.Comparer(func(x, y io.Reader) bool { return true }),
+		},
+	}, {
+		label:     label,
+		x:         []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
+		y:         []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label:    label,
+		x:        []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
+		y:        []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
+		opts:     []cmp.Option{cmp.Comparer(equalRegexp)},
+		wantDiff: "",
+	}, {
+		label:    label,
+		x:        []*regexp.Regexp{nil, regexp.MustCompile("a*b*c*")},
+		y:        []*regexp.Regexp{nil, regexp.MustCompile("a*b*d*")},
+		opts:     []cmp.Option{cmp.Comparer(equalRegexp)},
+		wantDiff: "{[]*regexp.Regexp}[1]:\n\t-: \"a*b*c*\"\n\t+: \"a*b*d*\"\n",
+	}, {
+		label: label,
+		x: func() ***int {
+			a := 0
+			b := &a
+			c := &b
+			return &c
+		}(),
+		y: func() ***int {
+			a := 0
+			b := &a
+			c := &b
+			return &c
+		}(),
+	}, {
+		label: label,
+		x: func() ***int {
+			a := 0
+			b := &a
+			c := &b
+			return &c
+		}(),
+		y: func() ***int {
+			a := 1
+			b := &a
+			c := &b
+			return &c
+		}(),
+		wantDiff: `
+***{***int}:
+	-: 0
+	+: 1`,
+	}, {
+		label: label,
+		x:     []int{1, 2, 3, 4, 5}[:3],
+		y:     []int{1, 2, 3},
+	}, {
+		label: label,
+		x:     struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
+		y:     struct{ fmt.Stringer }{regexp.MustCompile("hello")},
+		opts:  []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
+	}, {
+		label: label,
+		x:     struct{ fmt.Stringer }{bytes.NewBufferString("hello")},
+		y:     struct{ fmt.Stringer }{regexp.MustCompile("hello2")},
+		opts:  []cmp.Option{cmp.Comparer(func(x, y fmt.Stringer) bool { return x.String() == y.String() })},
+		wantDiff: `
+root:
+	-: "hello"
+	+: "hello2"`,
+	}, {
+		label: label,
+		x:     make([]int, 1000),
+		y:     make([]int, 1000),
+		opts: []cmp.Option{
+			cmp.Comparer(func(_, _ int) bool {
+				return rand.Intn(2) == 0
+			}),
+		},
+		wantPanic: "non-deterministic or non-symmetric function detected",
+	}, {
+		label: label,
+		x:     make([]int, 1000),
+		y:     make([]int, 1000),
+		opts: []cmp.Option{
+			cmp.FilterValues(func(_, _ int) bool {
+				return rand.Intn(2) == 0
+			}, cmp.Ignore()),
+		},
+		wantPanic: "non-deterministic or non-symmetric function detected",
+	}}
+}
+
+func transformerTests() []test {
+	const label = "Transformer/"
+
+	return []test{{
+		label: label,
+		x:     uint8(0),
+		y:     uint8(1),
+		opts: []cmp.Option{
+			cmp.Transformer("", func(in uint8) uint16 { return uint16(in) }),
+			cmp.Transformer("", func(in uint16) uint32 { return uint32(in) }),
+			cmp.Transformer("", func(in uint32) uint64 { return uint64(in) }),
+		},
+		wantDiff: `
+λ(λ(λ({uint8}))):
+	-: 0x00
+	+: 0x01`,
+	}, {
+		label: label,
+		x:     0,
+		y:     1,
+		opts: []cmp.Option{
+			cmp.Transformer("", func(in int) int { return in / 2 }),
+			cmp.Transformer("", func(in int) int { return in }),
+		},
+		wantPanic: "ambiguous set of options",
+	}, {
+		label: label,
+		x:     []int{0, -5, 0, -1},
+		y:     []int{1, 3, 0, -5},
+		opts: []cmp.Option{
+			cmp.FilterValues(
+				func(x, y int) bool { return x+y >= 0 },
+				cmp.Transformer("", func(in int) int64 { return int64(in / 2) }),
+			),
+			cmp.FilterValues(
+				func(x, y int) bool { return x+y < 0 },
+				cmp.Transformer("", func(in int) int64 { return int64(in) }),
+			),
+		},
+		wantDiff: `
+λ({[]int}[1]):
+	-: -5
+	+: 3
+λ({[]int}[3]):
+	-: -1
+	+: -5`,
+	}, {
+		label: label,
+		x:     0,
+		y:     1,
+		opts: []cmp.Option{
+			cmp.Transformer("", func(in int) interface{} {
+				if in == 0 {
+					return "string"
+				}
+				return in
+			}),
+		},
+		wantDiff: `
+λ({int}):
+	-: "string"
+	+: 1`,
+	}}
+}
+
+func embeddedTests() []test {
+	const label = "EmbeddedStruct/"
+
+	privateStruct := *new(ts.ParentStructA).PrivateStruct()
+
+	createStructA := func(i int) ts.ParentStructA {
+		s := ts.ParentStructA{}
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		return s
+	}
+
+	createStructB := func(i int) ts.ParentStructB {
+		s := ts.ParentStructB{}
+		s.PublicStruct.Public = 1 + i
+		s.PublicStruct.SetPrivate(2 + i)
+		return s
+	}
+
+	createStructC := func(i int) ts.ParentStructC {
+		s := ts.ParentStructC{}
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		s.Public = 3 + i
+		s.SetPrivate(4 + i)
+		return s
+	}
+
+	createStructD := func(i int) ts.ParentStructD {
+		s := ts.ParentStructD{}
+		s.PublicStruct.Public = 1 + i
+		s.PublicStruct.SetPrivate(2 + i)
+		s.Public = 3 + i
+		s.SetPrivate(4 + i)
+		return s
+	}
+
+	createStructE := func(i int) ts.ParentStructE {
+		s := ts.ParentStructE{}
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		s.PublicStruct.Public = 3 + i
+		s.PublicStruct.SetPrivate(4 + i)
+		return s
+	}
+
+	createStructF := func(i int) ts.ParentStructF {
+		s := ts.ParentStructF{}
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		s.PublicStruct.Public = 3 + i
+		s.PublicStruct.SetPrivate(4 + i)
+		s.Public = 5 + i
+		s.SetPrivate(6 + i)
+		return s
+	}
+
+	createStructG := func(i int) *ts.ParentStructG {
+		s := ts.NewParentStructG()
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		return s
+	}
+
+	createStructH := func(i int) *ts.ParentStructH {
+		s := ts.NewParentStructH()
+		s.PublicStruct.Public = 1 + i
+		s.PublicStruct.SetPrivate(2 + i)
+		return s
+	}
+
+	createStructI := func(i int) *ts.ParentStructI {
+		s := ts.NewParentStructI()
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		s.PublicStruct.Public = 3 + i
+		s.PublicStruct.SetPrivate(4 + i)
+		return s
+	}
+
+	createStructJ := func(i int) *ts.ParentStructJ {
+		s := ts.NewParentStructJ()
+		s.PrivateStruct().Public = 1 + i
+		s.PrivateStruct().SetPrivate(2 + i)
+		s.PublicStruct.Public = 3 + i
+		s.PublicStruct.SetPrivate(4 + i)
+		s.Private().Public = 5 + i
+		s.Private().SetPrivate(6 + i)
+		s.Public.Public = 7 + i
+		s.Public.SetPrivate(8 + i)
+		return s
+	}
+
+	return []test{{
+		label:     label + "ParentStructA",
+		x:         ts.ParentStructA{},
+		y:         ts.ParentStructA{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructA",
+		x:     ts.ParentStructA{},
+		y:     ts.ParentStructA{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructA{}),
+		},
+	}, {
+		label: label + "ParentStructA",
+		x:     createStructA(0),
+		y:     createStructA(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructA{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructA",
+		x:     createStructA(0),
+		y:     createStructA(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructA{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructA",
+		x:     createStructA(0),
+		y:     createStructA(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructA{}, privateStruct),
+		},
+		wantDiff: `
+{teststructs.ParentStructA}.privateStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructA}.privateStruct.private:
+	-: 2
+	+: 3`,
+	}, {
+		label: label + "ParentStructB",
+		x:     ts.ParentStructB{},
+		y:     ts.ParentStructB{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructB{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructB",
+		x:     ts.ParentStructB{},
+		y:     ts.ParentStructB{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructB{}),
+			IgnoreUnexported(ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructB",
+		x:     createStructB(0),
+		y:     createStructB(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructB{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructB",
+		x:     createStructB(0),
+		y:     createStructB(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructB{}, ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructB",
+		x:     createStructB(0),
+		y:     createStructB(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructB{}, ts.PublicStruct{}),
+		},
+		wantDiff: `
+{teststructs.ParentStructB}.PublicStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructB}.PublicStruct.private:
+	-: 2
+	+: 3`,
+	}, {
+		label:     label + "ParentStructC",
+		x:         ts.ParentStructC{},
+		y:         ts.ParentStructC{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructC",
+		x:     ts.ParentStructC{},
+		y:     ts.ParentStructC{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructC{}),
+		},
+	}, {
+		label: label + "ParentStructC",
+		x:     createStructC(0),
+		y:     createStructC(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructC{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructC",
+		x:     createStructC(0),
+		y:     createStructC(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructC{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructC",
+		x:     createStructC(0),
+		y:     createStructC(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructC{}, privateStruct),
+		},
+		wantDiff: `
+{teststructs.ParentStructC}.privateStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructC}.privateStruct.private:
+	-: 2
+	+: 3
+{teststructs.ParentStructC}.Public:
+	-: 3
+	+: 4
+{teststructs.ParentStructC}.private:
+	-: 4
+	+: 5`,
+	}, {
+		label: label + "ParentStructD",
+		x:     ts.ParentStructD{},
+		y:     ts.ParentStructD{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructD{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructD",
+		x:     ts.ParentStructD{},
+		y:     ts.ParentStructD{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructD{}),
+			IgnoreUnexported(ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructD",
+		x:     createStructD(0),
+		y:     createStructD(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructD{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructD",
+		x:     createStructD(0),
+		y:     createStructD(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructD{}, ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructD",
+		x:     createStructD(0),
+		y:     createStructD(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructD{}, ts.PublicStruct{}),
+		},
+		wantDiff: `
+{teststructs.ParentStructD}.PublicStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructD}.PublicStruct.private:
+	-: 2
+	+: 3
+{teststructs.ParentStructD}.Public:
+	-: 3
+	+: 4
+{teststructs.ParentStructD}.private:
+	-: 4
+	+: 5`,
+	}, {
+		label: label + "ParentStructE",
+		x:     ts.ParentStructE{},
+		y:     ts.ParentStructE{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructE{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructE",
+		x:     ts.ParentStructE{},
+		y:     ts.ParentStructE{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructE{}),
+			IgnoreUnexported(ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructE",
+		x:     createStructE(0),
+		y:     createStructE(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructE{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructE",
+		x:     createStructE(0),
+		y:     createStructE(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructE{}, ts.PublicStruct{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructE",
+		x:     createStructE(0),
+		y:     createStructE(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructE{}, ts.PublicStruct{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructE",
+		x:     createStructE(0),
+		y:     createStructE(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructE{}, ts.PublicStruct{}, privateStruct),
+		},
+		wantDiff: `
+{teststructs.ParentStructE}.privateStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructE}.privateStruct.private:
+	-: 2
+	+: 3
+{teststructs.ParentStructE}.PublicStruct.Public:
+	-: 3
+	+: 4
+{teststructs.ParentStructE}.PublicStruct.private:
+	-: 4
+	+: 5`,
+	}, {
+		label: label + "ParentStructF",
+		x:     ts.ParentStructF{},
+		y:     ts.ParentStructF{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructF{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructF",
+		x:     ts.ParentStructF{},
+		y:     ts.ParentStructF{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructF{}),
+			IgnoreUnexported(ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructF",
+		x:     createStructF(0),
+		y:     createStructF(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructF{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructF",
+		x:     createStructF(0),
+		y:     createStructF(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructF{}, ts.PublicStruct{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructF",
+		x:     createStructF(0),
+		y:     createStructF(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructF{}, ts.PublicStruct{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructF",
+		x:     createStructF(0),
+		y:     createStructF(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructF{}, ts.PublicStruct{}, privateStruct),
+		},
+		wantDiff: `
+{teststructs.ParentStructF}.privateStruct.Public:
+	-: 1
+	+: 2
+{teststructs.ParentStructF}.privateStruct.private:
+	-: 2
+	+: 3
+{teststructs.ParentStructF}.PublicStruct.Public:
+	-: 3
+	+: 4
+{teststructs.ParentStructF}.PublicStruct.private:
+	-: 4
+	+: 5
+{teststructs.ParentStructF}.Public:
+	-: 5
+	+: 6
+{teststructs.ParentStructF}.private:
+	-: 6
+	+: 7`,
+	}, {
+		label:     label + "ParentStructG",
+		x:         ts.ParentStructG{},
+		y:         ts.ParentStructG{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructG",
+		x:     ts.ParentStructG{},
+		y:     ts.ParentStructG{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructG{}),
+		},
+	}, {
+		label: label + "ParentStructG",
+		x:     createStructG(0),
+		y:     createStructG(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructG{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructG",
+		x:     createStructG(0),
+		y:     createStructG(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructG{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructG",
+		x:     createStructG(0),
+		y:     createStructG(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructG{}, privateStruct),
+		},
+		wantDiff: `
+{*teststructs.ParentStructG}.privateStruct.Public:
+	-: 1
+	+: 2
+{*teststructs.ParentStructG}.privateStruct.private:
+	-: 2
+	+: 3`,
+	}, {
+		label: label + "ParentStructH",
+		x:     ts.ParentStructH{},
+		y:     ts.ParentStructH{},
+	}, {
+		label:     label + "ParentStructH",
+		x:         createStructH(0),
+		y:         createStructH(0),
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructH",
+		x:     ts.ParentStructH{},
+		y:     ts.ParentStructH{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructH{}),
+		},
+	}, {
+		label: label + "ParentStructH",
+		x:     createStructH(0),
+		y:     createStructH(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructH{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructH",
+		x:     createStructH(0),
+		y:     createStructH(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructH{}, ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructH",
+		x:     createStructH(0),
+		y:     createStructH(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructH{}, ts.PublicStruct{}),
+		},
+		wantDiff: `
+{*teststructs.ParentStructH}.PublicStruct.Public:
+	-: 1
+	+: 2
+{*teststructs.ParentStructH}.PublicStruct.private:
+	-: 2
+	+: 3`,
+	}, {
+		label:     label + "ParentStructI",
+		x:         ts.ParentStructI{},
+		y:         ts.ParentStructI{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructI",
+		x:     ts.ParentStructI{},
+		y:     ts.ParentStructI{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructI{}),
+		},
+	}, {
+		label: label + "ParentStructI",
+		x:     createStructI(0),
+		y:     createStructI(0),
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructI{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructI",
+		x:     createStructI(0),
+		y:     createStructI(0),
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructI{}, ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructI",
+		x:     createStructI(0),
+		y:     createStructI(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructI{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructI",
+		x:     createStructI(0),
+		y:     createStructI(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructI{}, ts.PublicStruct{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructI",
+		x:     createStructI(0),
+		y:     createStructI(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructI{}, ts.PublicStruct{}, privateStruct),
+		},
+		wantDiff: `
+{*teststructs.ParentStructI}.privateStruct.Public:
+	-: 1
+	+: 2
+{*teststructs.ParentStructI}.privateStruct.private:
+	-: 2
+	+: 3
+{*teststructs.ParentStructI}.PublicStruct.Public:
+	-: 3
+	+: 4
+{*teststructs.ParentStructI}.PublicStruct.private:
+	-: 4
+	+: 5`,
+	}, {
+		label:     label + "ParentStructJ",
+		x:         ts.ParentStructJ{},
+		y:         ts.ParentStructJ{},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructJ",
+		x:     ts.ParentStructJ{},
+		y:     ts.ParentStructJ{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructJ{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructJ",
+		x:     ts.ParentStructJ{},
+		y:     ts.ParentStructJ{},
+		opts: []cmp.Option{
+			IgnoreUnexported(ts.ParentStructJ{}, ts.PublicStruct{}),
+		},
+	}, {
+		label: label + "ParentStructJ",
+		x:     createStructJ(0),
+		y:     createStructJ(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructJ{}, ts.PublicStruct{}),
+		},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label + "ParentStructJ",
+		x:     createStructJ(0),
+		y:     createStructJ(0),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructJ{}, ts.PublicStruct{}, privateStruct),
+		},
+	}, {
+		label: label + "ParentStructJ",
+		x:     createStructJ(0),
+		y:     createStructJ(1),
+		opts: []cmp.Option{
+			cmp.AllowUnexported(ts.ParentStructJ{}, ts.PublicStruct{}, privateStruct),
+		},
+		wantDiff: `
+{*teststructs.ParentStructJ}.privateStruct.Public:
+	-: 1
+	+: 2
+{*teststructs.ParentStructJ}.privateStruct.private:
+	-: 2
+	+: 3
+{*teststructs.ParentStructJ}.PublicStruct.Public:
+	-: 3
+	+: 4
+{*teststructs.ParentStructJ}.PublicStruct.private:
+	-: 4
+	+: 5
+{*teststructs.ParentStructJ}.Public.Public:
+	-: 7
+	+: 8
+{*teststructs.ParentStructJ}.Public.private:
+	-: 8
+	+: 9
+{*teststructs.ParentStructJ}.private.Public:
+	-: 5
+	+: 6
+{*teststructs.ParentStructJ}.private.private:
+	-: 6
+	+: 7`,
+	}}
+}
+
+func methodTests() []test {
+	const label = "EqualMethod/"
+
+	// A common mistake that the Equal method is on a pointer receiver,
+	// but only a non-pointer value is present in the struct.
+	// A transform can be used to forcibly reference the value.
+	derefTransform := cmp.FilterPath(func(p cmp.Path) bool {
+		if len(p) == 0 {
+			return false
+		}
+		t := p[len(p)-1].Type()
+		if _, ok := t.MethodByName("Equal"); ok || t.Kind() == reflect.Ptr {
+			return false
+		}
+		if m, ok := reflect.PtrTo(t).MethodByName("Equal"); ok {
+			tf := m.Func.Type()
+			return !tf.IsVariadic() && tf.NumIn() == 2 && tf.NumOut() == 1 &&
+				tf.In(0).AssignableTo(tf.In(1)) && tf.Out(0) == boolType
+		}
+		return false
+	}, cmp.Transformer("Ref", func(x interface{}) interface{} {
+		v := reflect.ValueOf(x)
+		vp := reflect.New(v.Type())
+		vp.Elem().Set(v)
+		return vp.Interface()
+	}))
+
+	// For each of these types, there is an Equal method defined, which always
+	// returns true, while the underlying data are fundamentally different.
+	// Since the method should be called, these are expected to be equal.
+	return []test{{
+		label: label + "StructA",
+		x:     ts.StructA{"NotEqual"},
+		y:     ts.StructA{"not_equal"},
+	}, {
+		label: label + "StructA",
+		x:     &ts.StructA{"NotEqual"},
+		y:     &ts.StructA{"not_equal"},
+	}, {
+		label: label + "StructB",
+		x:     ts.StructB{"NotEqual"},
+		y:     ts.StructB{"not_equal"},
+		wantDiff: `
+{teststructs.StructB}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructB",
+		x:     ts.StructB{"NotEqual"},
+		y:     ts.StructB{"not_equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label: label + "StructB",
+		x:     &ts.StructB{"NotEqual"},
+		y:     &ts.StructB{"not_equal"},
+	}, {
+		label: label + "StructC",
+		x:     ts.StructC{"NotEqual"},
+		y:     ts.StructC{"not_equal"},
+	}, {
+		label: label + "StructC",
+		x:     &ts.StructC{"NotEqual"},
+		y:     &ts.StructC{"not_equal"},
+	}, {
+		label: label + "StructD",
+		x:     ts.StructD{"NotEqual"},
+		y:     ts.StructD{"not_equal"},
+		wantDiff: `
+{teststructs.StructD}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructD",
+		x:     ts.StructD{"NotEqual"},
+		y:     ts.StructD{"not_equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label: label + "StructD",
+		x:     &ts.StructD{"NotEqual"},
+		y:     &ts.StructD{"not_equal"},
+	}, {
+		label: label + "StructE",
+		x:     ts.StructE{"NotEqual"},
+		y:     ts.StructE{"not_equal"},
+		wantDiff: `
+{teststructs.StructE}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructE",
+		x:     ts.StructE{"NotEqual"},
+		y:     ts.StructE{"not_equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label: label + "StructE",
+		x:     &ts.StructE{"NotEqual"},
+		y:     &ts.StructE{"not_equal"},
+	}, {
+		label: label + "StructF",
+		x:     ts.StructF{"NotEqual"},
+		y:     ts.StructF{"not_equal"},
+		wantDiff: `
+{teststructs.StructF}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructF",
+		x:     &ts.StructF{"NotEqual"},
+		y:     &ts.StructF{"not_equal"},
+	}, {
+		label: label + "StructA1",
+		x:     ts.StructA1{ts.StructA{"NotEqual"}, "equal"},
+		y:     ts.StructA1{ts.StructA{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructA1",
+		x:        ts.StructA1{ts.StructA{"NotEqual"}, "NotEqual"},
+		y:        ts.StructA1{ts.StructA{"not_equal"}, "not_equal"},
+		wantDiff: "{teststructs.StructA1}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructA1",
+		x:     &ts.StructA1{ts.StructA{"NotEqual"}, "equal"},
+		y:     &ts.StructA1{ts.StructA{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructA1",
+		x:        &ts.StructA1{ts.StructA{"NotEqual"}, "NotEqual"},
+		y:        &ts.StructA1{ts.StructA{"not_equal"}, "not_equal"},
+		wantDiff: "{*teststructs.StructA1}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructB1",
+		x:     ts.StructB1{ts.StructB{"NotEqual"}, "equal"},
+		y:     ts.StructB1{ts.StructB{"not_equal"}, "equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label:    label + "StructB1",
+		x:        ts.StructB1{ts.StructB{"NotEqual"}, "NotEqual"},
+		y:        ts.StructB1{ts.StructB{"not_equal"}, "not_equal"},
+		opts:     []cmp.Option{derefTransform},
+		wantDiff: "{teststructs.StructB1}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructB1",
+		x:     &ts.StructB1{ts.StructB{"NotEqual"}, "equal"},
+		y:     &ts.StructB1{ts.StructB{"not_equal"}, "equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label:    label + "StructB1",
+		x:        &ts.StructB1{ts.StructB{"NotEqual"}, "NotEqual"},
+		y:        &ts.StructB1{ts.StructB{"not_equal"}, "not_equal"},
+		opts:     []cmp.Option{derefTransform},
+		wantDiff: "{*teststructs.StructB1}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructC1",
+		x:     ts.StructC1{ts.StructC{"NotEqual"}, "NotEqual"},
+		y:     ts.StructC1{ts.StructC{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructC1",
+		x:     &ts.StructC1{ts.StructC{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructC1{ts.StructC{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructD1",
+		x:     ts.StructD1{ts.StructD{"NotEqual"}, "NotEqual"},
+		y:     ts.StructD1{ts.StructD{"not_equal"}, "not_equal"},
+		wantDiff: `
+{teststructs.StructD1}.StructD.X:
+	-: "NotEqual"
+	+: "not_equal"
+{teststructs.StructD1}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructD1",
+		x:     ts.StructD1{ts.StructD{"NotEqual"}, "NotEqual"},
+		y:     ts.StructD1{ts.StructD{"not_equal"}, "not_equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label: label + "StructD1",
+		x:     &ts.StructD1{ts.StructD{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructD1{ts.StructD{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructE1",
+		x:     ts.StructE1{ts.StructE{"NotEqual"}, "NotEqual"},
+		y:     ts.StructE1{ts.StructE{"not_equal"}, "not_equal"},
+		wantDiff: `
+{teststructs.StructE1}.StructE.X:
+	-: "NotEqual"
+	+: "not_equal"
+{teststructs.StructE1}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructE1",
+		x:     ts.StructE1{ts.StructE{"NotEqual"}, "NotEqual"},
+		y:     ts.StructE1{ts.StructE{"not_equal"}, "not_equal"},
+		opts:  []cmp.Option{derefTransform},
+	}, {
+		label: label + "StructE1",
+		x:     &ts.StructE1{ts.StructE{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructE1{ts.StructE{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructF1",
+		x:     ts.StructF1{ts.StructF{"NotEqual"}, "NotEqual"},
+		y:     ts.StructF1{ts.StructF{"not_equal"}, "not_equal"},
+		wantDiff: `
+{teststructs.StructF1}.StructF.X:
+	-: "NotEqual"
+	+: "not_equal"
+{teststructs.StructF1}.X:
+	-: "NotEqual"
+	+: "not_equal"`,
+	}, {
+		label: label + "StructF1",
+		x:     &ts.StructF1{ts.StructF{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructF1{ts.StructF{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructA2",
+		x:     ts.StructA2{&ts.StructA{"NotEqual"}, "equal"},
+		y:     ts.StructA2{&ts.StructA{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructA2",
+		x:        ts.StructA2{&ts.StructA{"NotEqual"}, "NotEqual"},
+		y:        ts.StructA2{&ts.StructA{"not_equal"}, "not_equal"},
+		wantDiff: "{teststructs.StructA2}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructA2",
+		x:     &ts.StructA2{&ts.StructA{"NotEqual"}, "equal"},
+		y:     &ts.StructA2{&ts.StructA{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructA2",
+		x:        &ts.StructA2{&ts.StructA{"NotEqual"}, "NotEqual"},
+		y:        &ts.StructA2{&ts.StructA{"not_equal"}, "not_equal"},
+		wantDiff: "{*teststructs.StructA2}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructB2",
+		x:     ts.StructB2{&ts.StructB{"NotEqual"}, "equal"},
+		y:     ts.StructB2{&ts.StructB{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructB2",
+		x:        ts.StructB2{&ts.StructB{"NotEqual"}, "NotEqual"},
+		y:        ts.StructB2{&ts.StructB{"not_equal"}, "not_equal"},
+		wantDiff: "{teststructs.StructB2}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructB2",
+		x:     &ts.StructB2{&ts.StructB{"NotEqual"}, "equal"},
+		y:     &ts.StructB2{&ts.StructB{"not_equal"}, "equal"},
+	}, {
+		label:    label + "StructB2",
+		x:        &ts.StructB2{&ts.StructB{"NotEqual"}, "NotEqual"},
+		y:        &ts.StructB2{&ts.StructB{"not_equal"}, "not_equal"},
+		wantDiff: "{*teststructs.StructB2}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "StructC2",
+		x:     ts.StructC2{&ts.StructC{"NotEqual"}, "NotEqual"},
+		y:     ts.StructC2{&ts.StructC{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructC2",
+		x:     &ts.StructC2{&ts.StructC{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructC2{&ts.StructC{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructD2",
+		x:     ts.StructD2{&ts.StructD{"NotEqual"}, "NotEqual"},
+		y:     ts.StructD2{&ts.StructD{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructD2",
+		x:     &ts.StructD2{&ts.StructD{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructD2{&ts.StructD{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructE2",
+		x:     ts.StructE2{&ts.StructE{"NotEqual"}, "NotEqual"},
+		y:     ts.StructE2{&ts.StructE{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructE2",
+		x:     &ts.StructE2{&ts.StructE{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructE2{&ts.StructE{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructF2",
+		x:     ts.StructF2{&ts.StructF{"NotEqual"}, "NotEqual"},
+		y:     ts.StructF2{&ts.StructF{"not_equal"}, "not_equal"},
+	}, {
+		label: label + "StructF2",
+		x:     &ts.StructF2{&ts.StructF{"NotEqual"}, "NotEqual"},
+		y:     &ts.StructF2{&ts.StructF{"not_equal"}, "not_equal"},
+	}, {
+		label:    label + "StructNo",
+		x:        ts.StructNo{"NotEqual"},
+		y:        ts.StructNo{"not_equal"},
+		wantDiff: "{teststructs.StructNo}.X:\n\t-: \"NotEqual\"\n\t+: \"not_equal\"\n",
+	}, {
+		label: label + "AssignA",
+		x:     ts.AssignA(func() int { return 0 }),
+		y:     ts.AssignA(func() int { return 1 }),
+	}, {
+		label: label + "AssignB",
+		x:     ts.AssignB(struct{ A int }{0}),
+		y:     ts.AssignB(struct{ A int }{1}),
+	}, {
+		label: label + "AssignC",
+		x:     ts.AssignC(make(chan bool)),
+		y:     ts.AssignC(make(chan bool)),
+	}, {
+		label: label + "AssignD",
+		x:     ts.AssignD(make(chan bool)),
+		y:     ts.AssignD(make(chan bool)),
+	}}
+}
+
+func project1Tests() []test {
+	const label = "Project1"
+
+	ignoreUnexported := IgnoreUnexported(
+		ts.EagleImmutable{},
+		ts.DreamerImmutable{},
+		ts.SlapImmutable{},
+		ts.GoatImmutable{},
+		ts.DonkeyImmutable{},
+		ts.LoveRadius{},
+		ts.SummerLove{},
+		ts.SummerLoveSummary{},
+	)
+
+	createEagle := func() ts.Eagle {
+		return ts.Eagle{
+			Name:   "eagle",
+			Hounds: []string{"buford", "tannen"},
+			Desc:   "some description",
+			Dreamers: []ts.Dreamer{{}, {
+				Name: "dreamer2",
+				Animal: []interface{}{
+					ts.Goat{
+						Target: "corporation",
+						Immutable: &ts.GoatImmutable{
+							ID:      "southbay",
+							State:   (*pb.Goat_States)(intPtr(5)),
+							Started: now,
+						},
+					},
+					ts.Donkey{},
+				},
+				Amoeba: 53,
+			}},
+			Slaps: []ts.Slap{{
+				Name: "slapID",
+				Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+				Immutable: &ts.SlapImmutable{
+					ID:       "immutableSlap",
+					MildSlap: true,
+					Started:  now,
+					LoveRadius: &ts.LoveRadius{
+						Summer: &ts.SummerLove{
+							Summary: &ts.SummerLoveSummary{
+								Devices:    []string{"foo", "bar", "baz"},
+								ChangeType: []pb.SummerType{1, 2, 3},
+							},
+						},
+					},
+				},
+			}},
+			Immutable: &ts.EagleImmutable{
+				ID:          "eagleID",
+				Birthday:    now,
+				MissingCall: (*pb.Eagle_MissingCalls)(intPtr(55)),
+			},
+		}
+	}
+
+	return []test{{
+		label: label,
+		x: ts.Eagle{Slaps: []ts.Slap{{
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+		}}},
+		y: ts.Eagle{Slaps: []ts.Slap{{
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+		}}},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x: ts.Eagle{Slaps: []ts.Slap{{
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+		}}},
+		y: ts.Eagle{Slaps: []ts.Slap{{
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+		}}},
+		opts:     []cmp.Option{cmp.Comparer(pb.Equal)},
+		wantDiff: "",
+	}, {
+		label: label,
+		x: ts.Eagle{Slaps: []ts.Slap{{}, {}, {}, {}, {
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata"}},
+		}}},
+		y: ts.Eagle{Slaps: []ts.Slap{{}, {}, {}, {}, {
+			Args: &pb.MetaData{Stringer: pb.Stringer{"metadata2"}},
+		}}},
+		opts:     []cmp.Option{cmp.Comparer(pb.Equal)},
+		wantDiff: "{teststructs.Eagle}.Slaps[4].Args:\n\t-: \"metadata\"\n\t+: \"metadata2\"\n",
+	}, {
+		label: label,
+		x:     createEagle(),
+		y:     createEagle(),
+		opts:  []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
+	}, {
+		label: label,
+		x: func() ts.Eagle {
+			eg := createEagle()
+			eg.Dreamers[1].Animal[0].(ts.Goat).Immutable.ID = "southbay2"
+			eg.Dreamers[1].Animal[0].(ts.Goat).Immutable.State = (*pb.Goat_States)(intPtr(6))
+			eg.Slaps[0].Immutable.MildSlap = false
+			return eg
+		}(),
+		y: func() ts.Eagle {
+			eg := createEagle()
+			devs := eg.Slaps[0].Immutable.LoveRadius.Summer.Summary.Devices
+			eg.Slaps[0].Immutable.LoveRadius.Summer.Summary.Devices = devs[:1]
+			return eg
+		}(),
+		opts: []cmp.Option{ignoreUnexported, cmp.Comparer(pb.Equal)},
+		wantDiff: `
+{teststructs.Eagle}.Dreamers[1].Animal[0].(teststructs.Goat).Immutable.ID:
+	-: "southbay2"
+	+: "southbay"
+*{teststructs.Eagle}.Dreamers[1].Animal[0].(teststructs.Goat).Immutable.State:
+	-: 6
+	+: 5
+{teststructs.Eagle}.Slaps[0].Immutable.MildSlap:
+	-: false
+	+: true
+{teststructs.Eagle}.Slaps[0].Immutable.LoveRadius.Summer.Summary.Devices[1]:
+	-: "bar"
+	+: <non-existent>
+{teststructs.Eagle}.Slaps[0].Immutable.LoveRadius.Summer.Summary.Devices[2]:
+	-: "baz"
+	+: <non-existent>`,
+	}}
+}
+
+type germSorter []*pb.Germ
+
+func (gs germSorter) Len() int           { return len(gs) }
+func (gs germSorter) Less(i, j int) bool { return gs[i].String() < gs[j].String() }
+func (gs germSorter) Swap(i, j int)      { gs[i], gs[j] = gs[j], gs[i] }
+
+func project2Tests() []test {
+	const label = "Project2"
+
+	sortGerms := cmp.FilterValues(func(x, y []*pb.Germ) bool {
+		ok1 := sort.IsSorted(germSorter(x))
+		ok2 := sort.IsSorted(germSorter(y))
+		return !ok1 || !ok2
+	}, cmp.Transformer("Sort", func(in []*pb.Germ) []*pb.Germ {
+		out := append([]*pb.Germ(nil), in...) // Make copy
+		sort.Sort(germSorter(out))
+		return out
+	}))
+
+	equalDish := cmp.Comparer(func(x, y *ts.Dish) bool {
+		if x == nil || y == nil {
+			return x == nil && y == nil
+		}
+		px, err1 := x.Proto()
+		py, err2 := y.Proto()
+		if err1 != nil || err2 != nil {
+			return err1 == err2
+		}
+		return pb.Equal(px, py)
+	})
+
+	createBatch := func() ts.GermBatch {
+		return ts.GermBatch{
+			DirtyGerms: map[int32][]*pb.Germ{
+				17: {
+					{Stringer: pb.Stringer{"germ1"}},
+				},
+				18: {
+					{Stringer: pb.Stringer{"germ2"}},
+					{Stringer: pb.Stringer{"germ3"}},
+					{Stringer: pb.Stringer{"germ4"}},
+				},
+			},
+			GermMap: map[int32]*pb.Germ{
+				13: {Stringer: pb.Stringer{"germ13"}},
+				21: {Stringer: pb.Stringer{"germ21"}},
+			},
+			DishMap: map[int32]*ts.Dish{
+				0: ts.CreateDish(nil, io.EOF),
+				1: ts.CreateDish(nil, io.ErrUnexpectedEOF),
+				2: ts.CreateDish(&pb.Dish{Stringer: pb.Stringer{"dish"}}, nil),
+			},
+			HasPreviousResult: true,
+			DirtyID:           10,
+			GermStrain:        421,
+			InfectedAt:        now,
+		}
+	}
+
+	return []test{{
+		label:     label,
+		x:         createBatch(),
+		y:         createBatch(),
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     createBatch(),
+		y:     createBatch(),
+		opts:  []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+	}, {
+		label: label,
+		x:     createBatch(),
+		y: func() ts.GermBatch {
+			gb := createBatch()
+			s := gb.DirtyGerms[18]
+			s[0], s[1], s[2] = s[1], s[2], s[0]
+			return gb
+		}(),
+		opts: []cmp.Option{cmp.Comparer(pb.Equal), equalDish},
+		wantDiff: `
+{teststructs.GermBatch}.DirtyGerms[18][0]:
+	-: "germ2"
+	+: "germ3"
+{teststructs.GermBatch}.DirtyGerms[18][1]:
+	-: "germ3"
+	+: "germ4"
+{teststructs.GermBatch}.DirtyGerms[18][2]:
+	-: "germ4"
+	+: "germ2"`,
+	}, {
+		label: label,
+		x:     createBatch(),
+		y: func() ts.GermBatch {
+			gb := createBatch()
+			s := gb.DirtyGerms[18]
+			s[0], s[1], s[2] = s[1], s[2], s[0]
+			return gb
+		}(),
+		opts: []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+	}, {
+		label: label,
+		x: func() ts.GermBatch {
+			gb := createBatch()
+			delete(gb.DirtyGerms, 17)
+			gb.DishMap[1] = nil
+			return gb
+		}(),
+		y: func() ts.GermBatch {
+			gb := createBatch()
+			gb.DirtyGerms[18] = gb.DirtyGerms[18][:2]
+			gb.GermStrain = 22
+			return gb
+		}(),
+		opts: []cmp.Option{cmp.Comparer(pb.Equal), sortGerms, equalDish},
+		wantDiff: `
+{teststructs.GermBatch}.DirtyGerms[17]:
+	-: <non-existent>
+	+: []*testprotos.Germ{"germ1"}
+{teststructs.GermBatch}.DirtyGerms[18][2]:
+	-: "germ4"
+	+: <non-existent>
+{teststructs.GermBatch}.DishMap[1]:
+	-: (*teststructs.Dish)(nil)
+	+: &teststructs.Dish{err: &errors.errorString{s: "unexpected EOF"}}
+{teststructs.GermBatch}.GermStrain:
+	-: 421
+	+: 22`,
+	}}
+}
+
+func project3Tests() []test {
+	const label = "Project3"
+
+	allowVisibility := cmp.AllowUnexported(ts.Dirt{})
+
+	ignoreLocker := cmp.FilterPath(func(p cmp.Path) bool {
+		return len(p) > 0 && p[len(p)-1].Type() == mutexType
+	}, cmp.Ignore())
+
+	transformProtos := cmp.Transformer("", func(x pb.Dirt) *pb.Dirt {
+		return &x
+	})
+
+	equalTable := cmp.Comparer(func(x, y ts.Table) bool {
+		tx, ok1 := x.(*ts.MockTable)
+		ty, ok2 := y.(*ts.MockTable)
+		if !ok1 || !ok2 {
+			panic("table type must be MockTable")
+		}
+		return cmp.Equal(tx.State(), ty.State())
+	})
+
+	createDirt := func() (d ts.Dirt) {
+		d.SetTable(ts.CreateMockTable([]string{"a", "b", "c"}))
+		d.SetTimestamp(12345)
+		d.Discord = 554
+		d.Proto = pb.Dirt{Stringer: pb.Stringer{"proto"}}
+		d.SetWizard(map[string]*pb.Wizard{
+			"harry": {Stringer: pb.Stringer{"potter"}},
+			"albus": {Stringer: pb.Stringer{"dumbledore"}},
+		})
+		d.SetLastTime(54321)
+		return d
+	}
+
+	return []test{{
+		label:     label,
+		x:         createDirt(),
+		y:         createDirt(),
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label:     label,
+		x:         createDirt(),
+		y:         createDirt(),
+		opts:      []cmp.Option{allowVisibility, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     createDirt(),
+		y:     createDirt(),
+		opts:  []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+	}, {
+		label: label,
+		x: func() ts.Dirt {
+			d := createDirt()
+			d.SetTable(ts.CreateMockTable([]string{"a", "c"}))
+			d.Proto = pb.Dirt{Stringer: pb.Stringer{"blah"}}
+			return d
+		}(),
+		y: func() ts.Dirt {
+			d := createDirt()
+			d.Discord = 500
+			d.SetWizard(map[string]*pb.Wizard{
+				"harry": {Stringer: pb.Stringer{"otter"}},
+			})
+			return d
+		}(),
+		opts: []cmp.Option{allowVisibility, transformProtos, ignoreLocker, cmp.Comparer(pb.Equal), equalTable},
+		wantDiff: `
+{teststructs.Dirt}.table:
+	-: &teststructs.MockTable{state: []string{"a", "c"}}
+	+: &teststructs.MockTable{state: []string{"a", "b", "c"}}
+{teststructs.Dirt}.Discord:
+	-: 554
+	+: 500
+λ({teststructs.Dirt}.Proto):
+	-: "blah"
+	+: "proto"
+{teststructs.Dirt}.wizard["albus"]:
+	-: "dumbledore"
+	+: <non-existent>
+{teststructs.Dirt}.wizard["harry"]:
+	-: "potter"
+	+: "otter"`,
+	}}
+}
+
+func project4Tests() []test {
+	const label = "Project4"
+
+	allowVisibility := cmp.AllowUnexported(
+		ts.Cartel{},
+		ts.Headquarter{},
+		ts.Poison{},
+	)
+
+	transformProtos := cmp.Transformer("", func(x pb.Restrictions) *pb.Restrictions {
+		return &x
+	})
+
+	createCartel := func() ts.Cartel {
+		var p ts.Poison
+		p.SetPoisonType(5)
+		p.SetExpiration(now)
+		p.SetManufactuer("acme")
+
+		var hq ts.Headquarter
+		hq.SetID(5)
+		hq.SetLocation("moon")
+		hq.SetSubDivisions([]string{"alpha", "bravo", "charlie"})
+		hq.SetMetaData(&pb.MetaData{Stringer: pb.Stringer{"metadata"}})
+		hq.SetPublicMessage([]byte{1, 2, 3, 4, 5})
+		hq.SetHorseBack("abcdef")
+		hq.SetStatus(44)
+
+		var c ts.Cartel
+		c.Headquarter = hq
+		c.SetSource("mars")
+		c.SetCreationTime(now)
+		c.SetBoss("al capone")
+		c.SetPoisons([]*ts.Poison{&p})
+
+		return c
+	}
+
+	return []test{{
+		label:     label,
+		x:         createCartel(),
+		y:         createCartel(),
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label:     label,
+		x:         createCartel(),
+		y:         createCartel(),
+		opts:      []cmp.Option{allowVisibility, cmp.Comparer(pb.Equal)},
+		wantPanic: "cannot handle unexported field",
+	}, {
+		label: label,
+		x:     createCartel(),
+		y:     createCartel(),
+		opts:  []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
+	}, {
+		label: label,
+		x: func() ts.Cartel {
+			d := createCartel()
+			var p1, p2 ts.Poison
+			p1.SetPoisonType(1)
+			p1.SetExpiration(now)
+			p1.SetManufactuer("acme")
+			p2.SetPoisonType(2)
+			p2.SetManufactuer("acme2")
+			d.SetPoisons([]*ts.Poison{&p1, &p2})
+			return d
+		}(),
+		y: func() ts.Cartel {
+			d := createCartel()
+			d.SetSubDivisions([]string{"bravo", "charlie"})
+			d.SetPublicMessage([]byte{1, 2, 4, 3, 5})
+			return d
+		}(),
+		opts: []cmp.Option{allowVisibility, transformProtos, cmp.Comparer(pb.Equal)},
+		wantDiff: `
+{teststructs.Cartel}.Headquarter.subDivisions[0]:
+	-: "alpha"
+	+: "bravo"
+{teststructs.Cartel}.Headquarter.subDivisions[1]:
+	-: "bravo"
+	+: "charlie"
+{teststructs.Cartel}.Headquarter.subDivisions[2]:
+	-: "charlie"
+	+: <non-existent>
+{teststructs.Cartel}.Headquarter.publicMessage[2]:
+	-: 0x03
+	+: 0x04
+{teststructs.Cartel}.Headquarter.publicMessage[3]:
+	-: 0x04
+	+: 0x03
+{teststructs.Cartel}.poisons[0].poisonType:
+	-: 1
+	+: 5
+{teststructs.Cartel}.poisons[1]:
+	-: &teststructs.Poison{poisonType: 2, manufactuer: "acme2"}
+	+: <non-existent>`,
+	}}
+}
+
+// TODO: Delete this hack when we drop Go1.6 support.
+func tRun(t *testing.T, name string, f func(t *testing.T)) {
+	type runner interface {
+		Run(string, func(t *testing.T)) bool
+	}
+	var ti interface{} = t
+	if r, ok := ti.(runner); ok {
+		r.Run(name, f)
+	} else {
+		t.Logf("Test: %s", name)
+		f(t)
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/example_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/example_test.go
@@ -1,0 +1,266 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp_test
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+// TODO: Re-write these examples in terms of how you actually use the
+// fundamental options and filters and not in terms of what cool things you can
+// do with them since that overlaps with cmp/cmpopts.
+
+// Approximate equality for floats can be handled by defining a custom
+// comparer on floats that determines two values to be equal if they are within
+// some range of each other.
+//
+// This example is for demonstrative purposes; use cmpopts.EquateApprox instead.
+func ExampleOption_approximateFloats() {
+	// This Comparer only operates on float64.
+	// To handle float32s, either define a similar function for that type
+	// or use a Transformer to convert float32s into float64s.
+	opt := cmp.Comparer(func(x, y float64) bool {
+		delta := math.Abs(x - y)
+		mean := math.Abs(x+y) / 2.0
+		return delta/mean < 0.00001
+	})
+
+	x := []float64{1.0, 1.1, 1.2, math.Pi}
+	y := []float64{1.0, 1.1, 1.2, 3.14159265359} // Accurate enough to Pi
+	z := []float64{1.0, 1.1, 1.2, 3.1415}        // Diverges too far from Pi
+
+	fmt.Println(cmp.Equal(x, y, opt))
+	fmt.Println(cmp.Equal(y, z, opt))
+	fmt.Println(cmp.Equal(z, x, opt))
+
+	// Output:
+	// true
+	// false
+	// false
+}
+
+// Normal floating-point arithmetic defines == to be false when comparing
+// NaN with itself. In certain cases, this is not the desired property.
+//
+// This example is for demonstrative purposes; use cmpopts.EquateNaNs instead.
+func ExampleOption_equalNaNs() {
+	// This Comparer only operates on float64.
+	// To handle float32s, either define a similar function for that type
+	// or use a Transformer to convert float32s into float64s.
+	opt := cmp.Comparer(func(x, y float64) bool {
+		return (math.IsNaN(x) && math.IsNaN(y)) || x == y
+	})
+
+	x := []float64{1.0, math.NaN(), math.E, -0.0, +0.0}
+	y := []float64{1.0, math.NaN(), math.E, -0.0, +0.0}
+	z := []float64{1.0, math.NaN(), math.Pi, -0.0, +0.0} // Pi constant instead of E
+
+	fmt.Println(cmp.Equal(x, y, opt))
+	fmt.Println(cmp.Equal(y, z, opt))
+	fmt.Println(cmp.Equal(z, x, opt))
+
+	// Output:
+	// true
+	// false
+	// false
+}
+
+// To have floating-point comparisons combine both properties of NaN being
+// equal to itself and also approximate equality of values, filters are needed
+// to restrict the scope of the comparison so that they are composable.
+//
+// This example is for demonstrative purposes;
+// use cmpopts.EquateNaNs and cmpopts.EquateApprox instead.
+func ExampleOption_equalNaNsAndApproximateFloats() {
+	alwaysEqual := cmp.Comparer(func(_, _ interface{}) bool { return true })
+
+	opts := cmp.Options{
+		// This option declares that a float64 comparison is equal only if
+		// both inputs are NaN.
+		cmp.FilterValues(func(x, y float64) bool {
+			return math.IsNaN(x) && math.IsNaN(y)
+		}, alwaysEqual),
+
+		// This option declares approximate equality on float64s only if
+		// both inputs are not NaN.
+		cmp.FilterValues(func(x, y float64) bool {
+			return !math.IsNaN(x) && !math.IsNaN(y)
+		}, cmp.Comparer(func(x, y float64) bool {
+			delta := math.Abs(x - y)
+			mean := math.Abs(x+y) / 2.0
+			return delta/mean < 0.00001
+		})),
+	}
+
+	x := []float64{math.NaN(), 1.0, 1.1, 1.2, math.Pi}
+	y := []float64{math.NaN(), 1.0, 1.1, 1.2, 3.14159265359} // Accurate enough to Pi
+	z := []float64{math.NaN(), 1.0, 1.1, 1.2, 3.1415}        // Diverges too far from Pi
+
+	fmt.Println(cmp.Equal(x, y, opts))
+	fmt.Println(cmp.Equal(y, z, opts))
+	fmt.Println(cmp.Equal(z, x, opts))
+
+	// Output:
+	// true
+	// false
+	// false
+}
+
+// Sometimes, an empty map or slice is considered equal to an allocated one
+// of zero length.
+//
+// This example is for demonstrative purposes; use cmpopts.EquateEmpty instead.
+func ExampleOption_equalEmpty() {
+	alwaysEqual := cmp.Comparer(func(_, _ interface{}) bool { return true })
+
+	// This option handles slices and maps of any type.
+	opt := cmp.FilterValues(func(x, y interface{}) bool {
+		vx, vy := reflect.ValueOf(x), reflect.ValueOf(y)
+		return (vx.IsValid() && vy.IsValid() && vx.Type() == vy.Type()) &&
+			(vx.Kind() == reflect.Slice || vx.Kind() == reflect.Map) &&
+			(vx.Len() == 0 && vy.Len() == 0)
+	}, alwaysEqual)
+
+	type S struct {
+		A []int
+		B map[string]bool
+	}
+	x := S{nil, make(map[string]bool, 100)}
+	y := S{make([]int, 0, 200), nil}
+	z := S{[]int{0}, nil} // []int has a single element (i.e., not empty)
+
+	fmt.Println(cmp.Equal(x, y, opt))
+	fmt.Println(cmp.Equal(y, z, opt))
+	fmt.Println(cmp.Equal(z, x, opt))
+
+	// Output:
+	// true
+	// false
+	// false
+}
+
+// Two slices may be considered equal if they have the same elements,
+// regardless of the order that they appear in. Transformations can be used
+// to sort the slice.
+//
+// This example is for demonstrative purposes; use cmpopts.SortSlices instead.
+func ExampleOption_sortedSlice() {
+	// This Transformer sorts a []int.
+	// Since the transformer transforms []int into []int, there is problem where
+	// this is recursively applied forever. To prevent this, use a FilterValues
+	// to first check for the condition upon which the transformer ought to apply.
+	trans := cmp.FilterValues(func(x, y []int) bool {
+		return !sort.IntsAreSorted(x) || !sort.IntsAreSorted(y)
+	}, cmp.Transformer("Sort", func(in []int) []int {
+		out := append([]int(nil), in...) // Copy input to avoid mutating it
+		sort.Ints(out)
+		return out
+	}))
+
+	x := struct{ Ints []int }{[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}
+	y := struct{ Ints []int }{[]int{2, 8, 0, 9, 6, 1, 4, 7, 3, 5}}
+	z := struct{ Ints []int }{[]int{0, 0, 1, 2, 3, 4, 5, 6, 7, 8}}
+
+	fmt.Println(cmp.Equal(x, y, trans))
+	fmt.Println(cmp.Equal(y, z, trans))
+	fmt.Println(cmp.Equal(z, x, trans))
+
+	// Output:
+	// true
+	// false
+	// false
+}
+
+type otherString string
+
+func (x otherString) Equal(y otherString) bool {
+	return strings.ToLower(string(x)) == strings.ToLower(string(y))
+}
+
+// If the Equal method defined on a type is not suitable, the type can be be
+// dynamically transformed to be stripped of the Equal method (or any method
+// for that matter).
+func ExampleOption_avoidEqualMethod() {
+	// Suppose otherString.Equal performs a case-insensitive equality,
+	// which is too loose for our needs.
+	// We can avoid the methods of otherString by declaring a new type.
+	type myString otherString
+
+	// This transformer converts otherString to myString, allowing Equal to use
+	// other Options to determine equality.
+	trans := cmp.Transformer("", func(in otherString) myString {
+		return myString(in)
+	})
+
+	x := []otherString{"foo", "bar", "baz"}
+	y := []otherString{"fOO", "bAr", "Baz"} // Same as before, but with different case
+
+	fmt.Println(cmp.Equal(x, y))        // Equal because of case-insensitivity
+	fmt.Println(cmp.Equal(x, y, trans)) // Not equal because of more exact equality
+
+	// Output:
+	// true
+	// false
+}
+
+func roundF64(z float64) float64 {
+	if z < 0 {
+		return math.Ceil(z - 0.5)
+	}
+	return math.Floor(z + 0.5)
+}
+
+// The complex numbers complex64 and complex128 can really just be decomposed
+// into a pair of float32 or float64 values. It would be convenient to be able
+// define only a single comparator on float64 and have float32, complex64, and
+// complex128 all be able to use that comparator. Transformations can be used
+// to handle this.
+func ExampleOption_transformComplex() {
+	opts := []cmp.Option{
+		// This transformer decomposes complex128 into a pair of float64s.
+		cmp.Transformer("T1", func(in complex128) (out struct{ Real, Imag float64 }) {
+			out.Real, out.Imag = real(in), imag(in)
+			return out
+		}),
+		// This transformer converts complex64 to complex128 to allow the
+		// above transform to take effect.
+		cmp.Transformer("T2", func(in complex64) complex128 {
+			return complex128(in)
+		}),
+		// This transformer converts float32 to float64.
+		cmp.Transformer("T3", func(in float32) float64 {
+			return float64(in)
+		}),
+		// This equality function compares float64s as rounded integers.
+		cmp.Comparer(func(x, y float64) bool {
+			return roundF64(x) == roundF64(y)
+		}),
+	}
+
+	x := []interface{}{
+		complex128(3.0), complex64(5.1 + 2.9i), float32(-1.2), float64(12.3),
+	}
+	y := []interface{}{
+		complex128(3.1), complex64(4.9 + 3.1i), float32(-1.3), float64(11.7),
+	}
+	z := []interface{}{
+		complex128(3.8), complex64(4.9 + 3.1i), float32(-1.3), float64(11.7),
+	}
+
+	fmt.Println(cmp.Equal(x, y, opts...))
+	fmt.Println(cmp.Equal(y, z, opts...))
+	fmt.Println(cmp.Equal(z, x, opts...))
+
+	// Output:
+	// true
+	// false
+	// false
+}

--- a/vendor/github.com/google/go-cmp/cmp/options.go
+++ b/vendor/github.com/google/go-cmp/cmp/options.go
@@ -1,0 +1,302 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+// Option configures for specific behavior of Equal and Diff. In particular,
+// the fundamental Option functions (Ignore, Transformer, and Comparer),
+// configure how equality is determined.
+//
+// The fundamental options may be composed with filters (FilterPath and
+// FilterValues) to control the scope over which they are applied.
+//
+// The cmp/cmpopts package provides helper functions for creating options that
+// may be used with Equal and Diff.
+type Option interface {
+	// Prevent Option from being equivalent to interface{}, which provides
+	// a small type checking benefit by preventing Equal(opt, x, y).
+	option()
+}
+
+// Options is a list of Option values that also satisfies the Option interface.
+// Helper comparison packages may return an Options value when packing multiple
+// Option values into a single Option. When this package processes an Options,
+// it will be implicitly expanded into a flat list.
+//
+// Applying a filter on an Options is equivalent to applying that same filter
+// on all individual options held within.
+type Options []Option
+
+func (Options) option() {}
+
+type (
+	pathFilter  func(Path) bool
+	valueFilter struct {
+		in  reflect.Type  // T
+		fnc reflect.Value // func(T, T) bool
+	}
+)
+
+type option struct {
+	typeFilter   reflect.Type
+	pathFilters  []pathFilter
+	valueFilters []valueFilter
+
+	// op is the operation to perform. If nil, then this acts as an ignore.
+	op interface{} // nil | *transformer | *comparer
+}
+
+func (option) option() {}
+
+func (o option) String() string {
+	// TODO: Add information about the caller?
+	// TODO: Maintain the order that filters were added?
+
+	var ss []string
+	switch op := o.op.(type) {
+	case *transformer:
+		fn := getFuncName(op.fnc.Pointer())
+		ss = append(ss, fmt.Sprintf("Transformer(%s, %s)", op.name, fn))
+	case *comparer:
+		fn := getFuncName(op.fnc.Pointer())
+		ss = append(ss, fmt.Sprintf("Comparer(%s)", fn))
+	default:
+		ss = append(ss, "Ignore()")
+	}
+
+	for _, f := range o.pathFilters {
+		fn := getFuncName(reflect.ValueOf(f).Pointer())
+		ss = append(ss, fmt.Sprintf("FilterPath(%s)", fn))
+	}
+	for _, f := range o.valueFilters {
+		fn := getFuncName(f.fnc.Pointer())
+		ss = append(ss, fmt.Sprintf("FilterValues(%s)", fn))
+	}
+	return strings.Join(ss, "\n\t")
+}
+
+// getFuncName returns a short function name from the pointer.
+// The string parsing logic works up until Go1.9.
+func getFuncName(p uintptr) string {
+	fnc := runtime.FuncForPC(p)
+	if fnc == nil {
+		return "<unknown>"
+	}
+	name := fnc.Name() // E.g., "long/path/name/mypkg.(mytype).(long/path/name/mypkg.myfunc)-fm"
+	if strings.HasSuffix(name, ")-fm") || strings.HasSuffix(name, ")·fm") {
+		// Strip the package name from method name.
+		name = strings.TrimSuffix(name, ")-fm")
+		name = strings.TrimSuffix(name, ")·fm")
+		if i := strings.LastIndexByte(name, '('); i >= 0 {
+			methodName := name[i+1:] // E.g., "long/path/name/mypkg.myfunc"
+			if j := strings.LastIndexByte(methodName, '.'); j >= 0 {
+				methodName = methodName[j+1:] // E.g., "myfunc"
+			}
+			name = name[:i] + methodName // E.g., "long/path/name/mypkg.(mytype)." + "myfunc"
+		}
+	}
+	if i := strings.LastIndexByte(name, '/'); i >= 0 {
+		// Strip the package name.
+		name = name[i+1:] // E.g., "mypkg.(mytype).myfunc"
+	}
+	return name
+}
+
+// FilterPath returns a new Option where opt is only evaluated if filter f
+// returns true for the current Path in the value tree.
+//
+// The option passed in may be an Ignore, Transformer, Comparer, Options, or
+// a previously filtered Option.
+func FilterPath(f func(Path) bool, opt Option) Option {
+	if f == nil {
+		panic("invalid path filter function")
+	}
+	switch opt := opt.(type) {
+	case Options:
+		var opts []Option
+		for _, o := range opt {
+			opts = append(opts, FilterPath(f, o)) // Append to slice copy
+		}
+		return Options(opts)
+	case option:
+		n := len(opt.pathFilters)
+		opt.pathFilters = append(opt.pathFilters[:n:n], f) // Append to copy
+		return opt
+	default:
+		panic(fmt.Sprintf("unknown option type: %T", opt))
+	}
+}
+
+// FilterValues returns a new Option where opt is only evaluated if filter f,
+// which is a function of the form "func(T, T) bool", returns true for the
+// current pair of values being compared. If the type of the values is not
+// assignable to T, then this filter implicitly returns false.
+//
+// The filter function must be
+// symmetric (i.e., agnostic to the order of the inputs) and
+// deterministic (i.e., produces the same result when given the same inputs).
+// If T is an interface, it is possible that f is called with two values with
+// different concrete types that both implement T.
+//
+// The option passed in may be an Ignore, Transformer, Comparer, Options, or
+// a previously filtered Option.
+func FilterValues(f interface{}, opt Option) Option {
+	v := reflect.ValueOf(f)
+	if functionType(v.Type()) != valueFilterFunc || v.IsNil() {
+		panic(fmt.Sprintf("invalid values filter function: %T", f))
+	}
+	switch opt := opt.(type) {
+	case Options:
+		var opts []Option
+		for _, o := range opt {
+			opts = append(opts, FilterValues(f, o)) // Append to slice copy
+		}
+		return Options(opts)
+	case option:
+		n := len(opt.valueFilters)
+		vf := valueFilter{v.Type().In(0), v}
+		opt.valueFilters = append(opt.valueFilters[:n:n], vf) // Append to copy
+		return opt
+	default:
+		panic(fmt.Sprintf("unknown option type: %T", opt))
+	}
+}
+
+// Ignore is an Option that causes all comparisons to be ignored.
+// This value is intended to be combined with FilterPath or FilterValues.
+// It is an error to pass an unfiltered Ignore option to Equal.
+func Ignore() Option {
+	return option{}
+}
+
+// Transformer returns an Option that applies a transformation function that
+// converts values of a certain type into that of another.
+//
+// The transformer f must be a function "func(T) R" that converts values of
+// type T to those of type R and is implicitly filtered to input values
+// assignable to T. The transformer must not mutate T in any way.
+// If T and R are the same type, an additional filter must be applied to
+// act as the base case to prevent an infinite recursion applying the same
+// transform to itself (see the SortedSlice example).
+//
+// The name is a user provided label that is used as the Transform.Name in the
+// transformation PathStep. If empty, an arbitrary name is used.
+func Transformer(name string, f interface{}) Option {
+	v := reflect.ValueOf(f)
+	if functionType(v.Type()) != transformFunc || v.IsNil() {
+		panic(fmt.Sprintf("invalid transformer function: %T", f))
+	}
+	if name == "" {
+		name = "λ" // Lambda-symbol as place-holder for anonymous transformer
+	}
+	if !isValid(name) {
+		panic(fmt.Sprintf("invalid name: %q", name))
+	}
+	opt := option{op: &transformer{name, reflect.ValueOf(f)}}
+	if ti := v.Type().In(0); ti.Kind() != reflect.Interface || ti.NumMethod() > 0 {
+		opt.typeFilter = ti
+	}
+	return opt
+}
+
+type transformer struct {
+	name string
+	fnc  reflect.Value // func(T) R
+}
+
+// Comparer returns an Option that determines whether two values are equal
+// to each other.
+//
+// The comparer f must be a function "func(T, T) bool" and is implicitly
+// filtered to input values assignable to T. If T is an interface, it is
+// possible that f is called with two values of different concrete types that
+// both implement T.
+//
+// The equality function must be:
+//	• Symmetric: equal(x, y) == equal(y, x)
+//	• Deterministic: equal(x, y) == equal(x, y)
+//	• Pure: equal(x, y) does not modify x or y
+func Comparer(f interface{}) Option {
+	v := reflect.ValueOf(f)
+	if functionType(v.Type()) != equalFunc || v.IsNil() {
+		panic(fmt.Sprintf("invalid comparer function: %T", f))
+	}
+	opt := option{op: &comparer{v}}
+	if ti := v.Type().In(0); ti.Kind() != reflect.Interface || ti.NumMethod() > 0 {
+		opt.typeFilter = ti
+	}
+	return opt
+}
+
+type comparer struct {
+	fnc reflect.Value // func(T, T) bool
+}
+
+// AllowUnexported returns an Option that forcibly allows operations on
+// unexported fields in certain structs, which are specified by passing in a
+// value of each struct type.
+//
+// Users of this option must understand that comparing on unexported fields
+// from external packages is not safe since changes in the internal
+// implementation of some external package may cause the result of Equal
+// to unexpectedly change. However, it may be valid to use this option on types
+// defined in an internal package where the semantic meaning of an unexported
+// field is in the control of the user.
+//
+// For most cases, a custom Comparer should be used instead that defines
+// equality as a function of the public API of a type rather than the underlying
+// unexported implementation.
+//
+// For example, the reflect.Type documentation defines equality to be determined
+// by the == operator on the interface (essentially performing a shallow pointer
+// comparison) and most attempts to compare *regexp.Regexp types are interested
+// in only checking that the regular expression strings are equal.
+// Both of these are accomplished using Comparers:
+//
+//	Comparer(func(x, y reflect.Type) bool { return x == y })
+//	Comparer(func(x, y *regexp.Regexp) bool { return x.String() == y.String() })
+//
+func AllowUnexported(types ...interface{}) Option {
+	if !supportAllowUnexported {
+		panic("AllowUnexported is not supported on App Engine Classic or GopherJS")
+	}
+	m := make(map[reflect.Type]bool)
+	for _, typ := range types {
+		t := reflect.TypeOf(typ)
+		if t.Kind() != reflect.Struct {
+			panic(fmt.Sprintf("invalid struct type: %T", typ))
+		}
+		m[t] = true
+	}
+	return visibleStructs(m)
+}
+
+type visibleStructs map[reflect.Type]bool
+
+func (visibleStructs) option() {}
+
+// reporter is an Option that configures how differences are reported.
+//
+// TODO: Not exported yet, see concerns in defaultReporter.Report.
+type reporter interface {
+	Option
+
+	// Report is called for every comparison made and will be provided with
+	// the two values being compared, the equality result, and the
+	// current path in the value tree. It is possible for x or y to be an
+	// invalid reflect.Value if one of the values is non-existent;
+	// which is possible with maps and slices.
+	Report(x, y reflect.Value, eq bool, p Path)
+
+	// TODO: Perhaps add PushStep and PopStep and change Report to only accept
+	// a PathStep instead of the full-path? This change allows us to provide
+	// better output closer to what pretty.Compare is able to achieve.
+}

--- a/vendor/github.com/google/go-cmp/cmp/options_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/options_test.go
@@ -1,0 +1,231 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	ts "github.com/google/go-cmp/cmp/internal/teststructs"
+)
+
+// Test that the creation of Option values with non-sensible inputs produces
+// a run-time panic with a decent error message
+func TestOptionPanic(t *testing.T) {
+	type myBool bool
+	tests := []struct {
+		label     string        // Test description
+		fnc       interface{}   // Option function to call
+		args      []interface{} // Arguments to pass in
+		wantPanic string        // Expected panic message
+	}{{
+		label: "AllowUnexported",
+		fnc:   AllowUnexported,
+		args:  []interface{}{},
+	}, {
+		label:     "AllowUnexported",
+		fnc:       AllowUnexported,
+		args:      []interface{}{1},
+		wantPanic: "invalid struct type",
+	}, {
+		label: "AllowUnexported",
+		fnc:   AllowUnexported,
+		args:  []interface{}{ts.StructA{}},
+	}, {
+		label: "AllowUnexported",
+		fnc:   AllowUnexported,
+		args:  []interface{}{ts.StructA{}, ts.StructB{}, ts.StructA{}},
+	}, {
+		label:     "AllowUnexported",
+		fnc:       AllowUnexported,
+		args:      []interface{}{ts.StructA{}, &ts.StructB{}, ts.StructA{}},
+		wantPanic: "invalid struct type",
+	}, {
+		label:     "Comparer",
+		fnc:       Comparer,
+		args:      []interface{}{5},
+		wantPanic: "invalid comparer function",
+	}, {
+		label: "Comparer",
+		fnc:   Comparer,
+		args:  []interface{}{func(x, y interface{}) bool { return true }},
+	}, {
+		label: "Comparer",
+		fnc:   Comparer,
+		args:  []interface{}{func(x, y io.Reader) bool { return true }},
+	}, {
+		label:     "Comparer",
+		fnc:       Comparer,
+		args:      []interface{}{func(x, y io.Reader) myBool { return true }},
+		wantPanic: "invalid comparer function",
+	}, {
+		label:     "Comparer",
+		fnc:       Comparer,
+		args:      []interface{}{func(x string, y interface{}) bool { return true }},
+		wantPanic: "invalid comparer function",
+	}, {
+		label:     "Comparer",
+		fnc:       Comparer,
+		args:      []interface{}{(func(int, int) bool)(nil)},
+		wantPanic: "invalid comparer function",
+	}, {
+		label:     "Transformer",
+		fnc:       Transformer,
+		args:      []interface{}{"", 0},
+		wantPanic: "invalid transformer function",
+	}, {
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"", func(int) int { return 0 }},
+	}, {
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"", func(bool) bool { return true }},
+	}, {
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"", func(int) bool { return true }},
+	}, {
+		label:     "Transformer",
+		fnc:       Transformer,
+		args:      []interface{}{"", func(int, int) bool { return true }},
+		wantPanic: "invalid transformer function",
+	}, {
+		label:     "Transformer",
+		fnc:       Transformer,
+		args:      []interface{}{"", (func(int) uint)(nil)},
+		wantPanic: "invalid transformer function",
+	}, {
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"Func", func(Path) Path { return nil }},
+	}, {
+		label: "Transformer",
+		fnc:   Transformer,
+		args:  []interface{}{"世界", func(int) bool { return true }},
+	}, {
+		label:     "Transformer",
+		fnc:       Transformer,
+		args:      []interface{}{"/*", func(int) bool { return true }},
+		wantPanic: "invalid name",
+	}, {
+		label:     "Transformer",
+		fnc:       Transformer,
+		args:      []interface{}{"_", func(int) bool { return true }},
+		wantPanic: "invalid name",
+	}, {
+		label:     "FilterPath",
+		fnc:       FilterPath,
+		args:      []interface{}{(func(Path) bool)(nil), Ignore()},
+		wantPanic: "invalid path filter function",
+	}, {
+		label: "FilterPath",
+		fnc:   FilterPath,
+		args:  []interface{}{func(Path) bool { return true }, Ignore()},
+	}, {
+		label:     "FilterPath",
+		fnc:       FilterPath,
+		args:      []interface{}{func(Path) bool { return true }, &defaultReporter{}},
+		wantPanic: "unknown option type",
+	}, {
+		label: "FilterPath",
+		fnc:   FilterPath,
+		args:  []interface{}{func(Path) bool { return true }, Options{Ignore(), Ignore()}},
+	}, {
+		label:     "FilterPath",
+		fnc:       FilterPath,
+		args:      []interface{}{func(Path) bool { return true }, Options{Ignore(), &defaultReporter{}}},
+		wantPanic: "unknown option type",
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{0, Ignore()},
+		wantPanic: "invalid values filter function",
+	}, {
+		label: "FilterValues",
+		fnc:   FilterValues,
+		args:  []interface{}{func(x, y int) bool { return true }, Ignore()},
+	}, {
+		label: "FilterValues",
+		fnc:   FilterValues,
+		args:  []interface{}{func(x, y interface{}) bool { return true }, Ignore()},
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{func(x, y interface{}) myBool { return true }, Ignore()},
+		wantPanic: "invalid values filter function",
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{func(x io.Reader, y interface{}) bool { return true }, Ignore()},
+		wantPanic: "invalid values filter function",
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{(func(int, int) bool)(nil), Ignore()},
+		wantPanic: "invalid values filter function",
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{func(int, int) bool { return true }, &defaultReporter{}},
+		wantPanic: "unknown option type",
+	}, {
+		label: "FilterValues",
+		fnc:   FilterValues,
+		args:  []interface{}{func(int, int) bool { return true }, Options{Ignore(), Ignore()}},
+	}, {
+		label:     "FilterValues",
+		fnc:       FilterValues,
+		args:      []interface{}{func(int, int) bool { return true }, Options{Ignore(), &defaultReporter{}}},
+		wantPanic: "unknown option type",
+	}}
+
+	for _, tt := range tests {
+		tRun(t, tt.label, func(t *testing.T) {
+			var gotPanic string
+			func() {
+				defer func() {
+					if ex := recover(); ex != nil {
+						if s, ok := ex.(string); ok {
+							gotPanic = s
+						} else {
+							panic(ex)
+						}
+					}
+				}()
+				var vargs []reflect.Value
+				for _, arg := range tt.args {
+					vargs = append(vargs, reflect.ValueOf(arg))
+				}
+				reflect.ValueOf(tt.fnc).Call(vargs)
+			}()
+			if tt.wantPanic == "" {
+				if gotPanic != "" {
+					t.Fatalf("unexpected panic message: %s", gotPanic)
+				}
+			} else {
+				if !strings.Contains(gotPanic, tt.wantPanic) {
+					t.Fatalf("panic message:\ngot:  %s\nwant: %s", gotPanic, tt.wantPanic)
+				}
+			}
+		})
+	}
+}
+
+// TODO: Delete this hack when we drop Go1.6 support.
+func tRun(t *testing.T, name string, f func(t *testing.T)) {
+	type runner interface {
+		Run(string, func(t *testing.T)) bool
+	}
+	var ti interface{} = t
+	if r, ok := ti.(runner); ok {
+		r.Run(name, f)
+	} else {
+		t.Logf("Test: %s", name)
+		f(t)
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/path.go
+++ b/vendor/github.com/google/go-cmp/cmp/path.go
@@ -1,0 +1,261 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+type (
+	// Path is a list of PathSteps describing the sequence of operations to get
+	// from some root type to the current position in the value tree.
+	// The first Path element is always an operation-less PathStep that exists
+	// simply to identify the initial type.
+	//
+	// When traversing structs with embedded structs, the embedded struct will
+	// always be accessed as a field before traversing the fields of the
+	// embedded struct themselves. That is, an exported field from the
+	// embedded struct will never be accessed directly from the parent struct.
+	Path []PathStep
+
+	// PathStep is a union-type for specific operations to traverse
+	// a value's tree structure. Users of this package never need to implement
+	// these types as values of this type will be returned by this package.
+	PathStep interface {
+		String() string
+		Type() reflect.Type // Resulting type after performing the path step
+		isPathStep()
+	}
+
+	// SliceIndex is an index operation on a slice or array at some index Key.
+	SliceIndex interface {
+		PathStep
+		Key() int
+		isSliceIndex()
+	}
+	// MapIndex is an index operation on a map at some index Key.
+	MapIndex interface {
+		PathStep
+		Key() reflect.Value
+		isMapIndex()
+	}
+	// TypeAssertion represents a type assertion on an interface.
+	TypeAssertion interface {
+		PathStep
+		isTypeAssertion()
+	}
+	// StructField represents a struct field access on a field called Name.
+	StructField interface {
+		PathStep
+		Name() string
+		Index() int
+		isStructField()
+	}
+	// Indirect represents pointer indirection on the parent type.
+	Indirect interface {
+		PathStep
+		isIndirect()
+	}
+	// Transform is a transformation from the parent type to the current type.
+	Transform interface {
+		PathStep
+		Name() string
+		Func() reflect.Value
+		isTransform()
+	}
+)
+
+func (pa *Path) push(s PathStep) {
+	*pa = append(*pa, s)
+}
+
+func (pa *Path) pop() {
+	*pa = (*pa)[:len(*pa)-1]
+}
+
+// Last returns the last PathStep in the Path.
+// If the path is empty, this returns a non-nil PathStep that reports a nil Type.
+func (pa Path) Last() PathStep {
+	if len(pa) > 0 {
+		return pa[len(pa)-1]
+	}
+	return pathStep{}
+}
+
+// String returns the simplified path to a node.
+// The simplified path only contains struct field accesses.
+//
+// For example:
+//	MyMap.MySlices.MyField
+func (pa Path) String() string {
+	var ss []string
+	for _, s := range pa {
+		if _, ok := s.(*structField); ok {
+			ss = append(ss, s.String())
+		}
+	}
+	return strings.TrimPrefix(strings.Join(ss, ""), ".")
+}
+
+// GoString returns the path to a specific node using Go syntax.
+//
+// For example:
+//	(*root.MyMap["key"].(*mypkg.MyStruct).MySlices)[2][3].MyField
+func (pa Path) GoString() string {
+	var ssPre, ssPost []string
+	var numIndirect int
+	for i, s := range pa {
+		var nextStep PathStep
+		if i+1 < len(pa) {
+			nextStep = pa[i+1]
+		}
+		switch s := s.(type) {
+		case *indirect:
+			numIndirect++
+			pPre, pPost := "(", ")"
+			switch nextStep.(type) {
+			case *indirect:
+				continue // Next step is indirection, so let them batch up
+			case *structField:
+				numIndirect-- // Automatic indirection on struct fields
+			case nil:
+				pPre, pPost = "", "" // Last step; no need for parenthesis
+			}
+			if numIndirect > 0 {
+				ssPre = append(ssPre, pPre+strings.Repeat("*", numIndirect))
+				ssPost = append(ssPost, pPost)
+			}
+			numIndirect = 0
+			continue
+		case *transform:
+			ssPre = append(ssPre, s.trans.name+"(")
+			ssPost = append(ssPost, ")")
+			continue
+		case *typeAssertion:
+			// Elide type assertions immediately following a transform to
+			// prevent overly verbose path printouts.
+			// Some transforms return interface{} because of Go's lack of
+			// generics, but typically take in and return the exact same
+			// concrete type. Other times, the transform creates an anonymous
+			// struct, which will be very verbose to print.
+			if _, ok := nextStep.(*transform); ok {
+				continue
+			}
+		}
+		ssPost = append(ssPost, s.String())
+	}
+	for i, j := 0, len(ssPre)-1; i < j; i, j = i+1, j-1 {
+		ssPre[i], ssPre[j] = ssPre[j], ssPre[i]
+	}
+	return strings.Join(ssPre, "") + strings.Join(ssPost, "")
+}
+
+type (
+	pathStep struct {
+		typ reflect.Type
+	}
+
+	sliceIndex struct {
+		pathStep
+		key int
+	}
+	mapIndex struct {
+		pathStep
+		key reflect.Value
+	}
+	typeAssertion struct {
+		pathStep
+	}
+	structField struct {
+		pathStep
+		name string
+		idx  int
+
+		// These fields are used for forcibly accessing an unexported field.
+		// pvx, pvy, and field are only valid if unexported is true.
+		unexported bool
+		force      bool                // Forcibly allow visibility
+		pvx, pvy   reflect.Value       // Parent values
+		field      reflect.StructField // Field information
+	}
+	indirect struct {
+		pathStep
+	}
+	transform struct {
+		pathStep
+		trans *transformer
+	}
+)
+
+func (ps pathStep) Type() reflect.Type { return ps.typ }
+func (ps pathStep) String() string {
+	if ps.typ == nil {
+		return "<nil>"
+	}
+	s := ps.typ.String()
+	if s == "" || strings.ContainsAny(s, "{}\n") {
+		return "root" // Type too simple or complex to print
+	}
+	return fmt.Sprintf("{%s}", s)
+}
+
+func (si sliceIndex) String() string    { return fmt.Sprintf("[%d]", si.key) }
+func (mi mapIndex) String() string      { return fmt.Sprintf("[%#v]", mi.key) }
+func (ta typeAssertion) String() string { return fmt.Sprintf(".(%v)", ta.typ) }
+func (sf structField) String() string   { return fmt.Sprintf(".%s", sf.name) }
+func (in indirect) String() string      { return "*" }
+func (tf transform) String() string     { return fmt.Sprintf("%s()", tf.trans.name) }
+
+func (si sliceIndex) Key() int           { return si.key }
+func (mi mapIndex) Key() reflect.Value   { return mi.key }
+func (sf structField) Name() string      { return sf.name }
+func (sf structField) Index() int        { return sf.idx }
+func (tf transform) Name() string        { return tf.trans.name }
+func (tf transform) Func() reflect.Value { return tf.trans.fnc }
+
+func (pathStep) isPathStep()           {}
+func (sliceIndex) isSliceIndex()       {}
+func (mapIndex) isMapIndex()           {}
+func (typeAssertion) isTypeAssertion() {}
+func (structField) isStructField()     {}
+func (indirect) isIndirect()           {}
+func (transform) isTransform()         {}
+
+var (
+	_ SliceIndex    = sliceIndex{}
+	_ MapIndex      = mapIndex{}
+	_ TypeAssertion = typeAssertion{}
+	_ StructField   = structField{}
+	_ Indirect      = indirect{}
+	_ Transform     = transform{}
+
+	_ PathStep = sliceIndex{}
+	_ PathStep = mapIndex{}
+	_ PathStep = typeAssertion{}
+	_ PathStep = structField{}
+	_ PathStep = indirect{}
+	_ PathStep = transform{}
+)
+
+// isExported reports whether the identifier is exported.
+func isExported(id string) bool {
+	r, _ := utf8.DecodeRuneInString(id)
+	return unicode.IsUpper(r)
+}
+
+// isValid reports whether the identifier is valid.
+// Empty and underscore-only strings are not valid.
+func isValid(id string) bool {
+	ok := id != "" && id != "_"
+	for j, c := range id {
+		ok = ok && (j > 0 || !unicode.IsDigit(c))
+		ok = ok && (c == '_' || unicode.IsLetter(c) || unicode.IsDigit(c))
+	}
+	return ok
+}

--- a/vendor/github.com/google/go-cmp/cmp/reporter.go
+++ b/vendor/github.com/google/go-cmp/cmp/reporter.go
@@ -1,0 +1,406 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// TODO: Can we leave the interface for a reporter here in the cmp package
+// and somehow extract the implementation of defaultReporter into cmp/report?
+
+type defaultReporter struct {
+	Option
+	diffs  []string // List of differences, possibly truncated
+	ndiffs int      // Total number of differences
+	nbytes int      // Number of bytes in diffs
+	nlines int      // Number of lines in diffs
+}
+
+var _ reporter = (*defaultReporter)(nil)
+
+func (r *defaultReporter) Report(x, y reflect.Value, eq bool, p Path) {
+	// TODO: Is there a way to nicely print added/modified/removed elements
+	// from a slice? This will most certainly require support from the
+	// equality logic, but what would be the right API for this?
+	//
+	// The current API is equivalent to a Hamming distance for measuring the
+	// difference between two sequences of symbols. That is, the only operation
+	// we can represent is substitution. The new API would need to handle a
+	// Levenshtein distance, such that insertions, deletions, and substitutions
+	// are permitted. Furthermore, this will require an algorithm for computing
+	// the edit distance. Unfortunately, the time complexity for a minimal
+	// edit distance algorithm is not much better than O(n^2).
+	// There are approximations for the algorithm that can run much faster.
+	// See literature on computing Levenshtein distance.
+	//
+	// Passing in a pair of x and y is actually good for representing insertion
+	// and deletion by the fact that x or y may be an invalid value. However,
+	// we may need to pass in two paths px and py, to indicate the paths
+	// relative to x and y. Alternative, since we only perform the Levenshtein
+	// distance on slices, maybe we alter the SliceIndex type to record
+	// two different indexes.
+
+	// TODO: Perhaps we should coalesce differences on primitive kinds
+	// together if the number of differences exceeds some ratio.
+	// For example, comparing two SHA256s leads to many byte differences.
+
+	if eq {
+		// TODO: Maybe print some equal results for context?
+		return // Ignore equal results
+	}
+	const maxBytes = 4096
+	const maxLines = 256
+	r.ndiffs++
+	if r.nbytes < maxBytes && r.nlines < maxLines {
+		sx := prettyPrint(x, true)
+		sy := prettyPrint(y, true)
+		if sx == sy {
+			// Use of Stringer is not helpful, so rely on more exact formatting.
+			sx = prettyPrint(x, false)
+			sy = prettyPrint(y, false)
+		}
+		s := fmt.Sprintf("%#v:\n\t-: %s\n\t+: %s\n", p, sx, sy)
+		r.diffs = append(r.diffs, s)
+		r.nbytes += len(s)
+		r.nlines += strings.Count(s, "\n")
+	}
+}
+
+func (r *defaultReporter) String() string {
+	s := strings.Join(r.diffs, "")
+	if r.ndiffs == len(r.diffs) {
+		return s
+	}
+	return fmt.Sprintf("%s... %d more differences ...", s, len(r.diffs)-r.ndiffs)
+}
+
+var stringerIface = reflect.TypeOf((*fmt.Stringer)(nil)).Elem()
+
+func prettyPrint(v reflect.Value, useStringer bool) string {
+	return formatAny(v, formatConfig{useStringer, true, true, true}, nil)
+}
+
+type formatConfig struct {
+	useStringer    bool // Should the String method be used if available?
+	printType      bool // Should we print the type before the value?
+	followPointers bool // Should we recursively follow pointers?
+	realPointers   bool // Should we print the real address of pointers?
+}
+
+// formatAny prints the value v in a pretty formatted manner.
+// This is similar to fmt.Sprintf("%+v", v) except this:
+//	* Prints the type unless it can be elided.
+//	* Avoids printing struct fields that are zero.
+//	* Prints a nil-slice as being nil, not empty.
+//	* Prints map entries in deterministic order.
+func formatAny(v reflect.Value, conf formatConfig, visited map[uintptr]bool) string {
+	// TODO: Should this be a multi-line printout in certain situations?
+
+	if !v.IsValid() {
+		return "<non-existent>"
+	}
+	if conf.useStringer && v.Type().Implements(stringerIface) {
+		if v.Kind() == reflect.Ptr && v.IsNil() {
+			return "<nil>"
+		}
+		return fmt.Sprintf("%q", v.Interface().(fmt.Stringer).String())
+	}
+
+	switch v.Kind() {
+	case reflect.Bool:
+		return fmt.Sprint(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return fmt.Sprint(v.Int())
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		if v.Type().PkgPath() == "" || v.Kind() == reflect.Uintptr {
+			return formatHex(v.Uint()) // Unnamed uints are usually bytes or words
+		}
+		return fmt.Sprint(v.Uint()) // Named uints are usually enumerations
+	case reflect.Float32, reflect.Float64:
+		return fmt.Sprint(v.Float())
+	case reflect.Complex64, reflect.Complex128:
+		return fmt.Sprint(v.Complex())
+	case reflect.String:
+		return fmt.Sprintf("%q", v)
+	case reflect.UnsafePointer, reflect.Chan, reflect.Func:
+		return formatPointer(v, conf)
+	case reflect.Ptr:
+		if v.IsNil() {
+			if conf.printType {
+				return fmt.Sprintf("(%v)(nil)", v.Type())
+			}
+			return "<nil>"
+		}
+		if visited[v.Pointer()] || !conf.followPointers {
+			return formatPointer(v, conf)
+		}
+		visited = insertPointer(visited, v.Pointer())
+		return "&" + formatAny(v.Elem(), conf, visited)
+	case reflect.Interface:
+		if v.IsNil() {
+			if conf.printType {
+				return fmt.Sprintf("%v(nil)", v.Type())
+			}
+			return "<nil>"
+		}
+		return formatAny(v.Elem(), conf, visited)
+	case reflect.Slice:
+		if v.IsNil() {
+			if conf.printType {
+				return fmt.Sprintf("%v(nil)", v.Type())
+			}
+			return "<nil>"
+		}
+		if visited[v.Pointer()] {
+			return formatPointer(v, conf)
+		}
+		visited = insertPointer(visited, v.Pointer())
+		fallthrough
+	case reflect.Array:
+		var ss []string
+		subConf := conf
+		subConf.printType = v.Type().Elem().Kind() == reflect.Interface
+		for i := 0; i < v.Len(); i++ {
+			s := formatAny(v.Index(i), subConf, visited)
+			ss = append(ss, s)
+		}
+		s := fmt.Sprintf("{%s}", strings.Join(ss, ", "))
+		if conf.printType {
+			return v.Type().String() + s
+		}
+		return s
+	case reflect.Map:
+		if v.IsNil() {
+			if conf.printType {
+				return fmt.Sprintf("%v(nil)", v.Type())
+			}
+			return "<nil>"
+		}
+		if visited[v.Pointer()] {
+			return formatPointer(v, conf)
+		}
+		visited = insertPointer(visited, v.Pointer())
+
+		var ss []string
+		subConf := conf
+		subConf.printType = v.Type().Elem().Kind() == reflect.Interface
+		for _, k := range sortKeys(v.MapKeys()) {
+			sk := formatAny(k, formatConfig{realPointers: conf.realPointers}, visited)
+			sv := formatAny(v.MapIndex(k), subConf, visited)
+			ss = append(ss, fmt.Sprintf("%s: %s", sk, sv))
+		}
+		s := fmt.Sprintf("{%s}", strings.Join(ss, ", "))
+		if conf.printType {
+			return v.Type().String() + s
+		}
+		return s
+	case reflect.Struct:
+		var ss []string
+		subConf := conf
+		subConf.printType = true
+		for i := 0; i < v.NumField(); i++ {
+			vv := v.Field(i)
+			if isZero(vv) {
+				continue // Elide zero value fields
+			}
+			name := v.Type().Field(i).Name
+			subConf.useStringer = conf.useStringer && isExported(name)
+			s := formatAny(vv, subConf, visited)
+			ss = append(ss, fmt.Sprintf("%s: %s", name, s))
+		}
+		s := fmt.Sprintf("{%s}", strings.Join(ss, ", "))
+		if conf.printType {
+			return v.Type().String() + s
+		}
+		return s
+	default:
+		panic(fmt.Sprintf("%v kind not handled", v.Kind()))
+	}
+}
+
+func formatPointer(v reflect.Value, conf formatConfig) string {
+	p := v.Pointer()
+	if !conf.realPointers {
+		p = 0 // For deterministic printing purposes
+	}
+	s := formatHex(uint64(p))
+	if conf.printType {
+		return fmt.Sprintf("(%v)(%s)", v.Type(), s)
+	}
+	return s
+}
+
+func formatHex(u uint64) string {
+	var f string
+	switch {
+	case u <= 0xff:
+		f = "0x%02x"
+	case u <= 0xffff:
+		f = "0x%04x"
+	case u <= 0xffffff:
+		f = "0x%06x"
+	case u <= 0xffffffff:
+		f = "0x%08x"
+	case u <= 0xffffffffff:
+		f = "0x%010x"
+	case u <= 0xffffffffffff:
+		f = "0x%012x"
+	case u <= 0xffffffffffffff:
+		f = "0x%014x"
+	case u <= 0xffffffffffffffff:
+		f = "0x%016x"
+	}
+	return fmt.Sprintf(f, u)
+}
+
+// insertPointer insert p into m, allocating m if necessary.
+func insertPointer(m map[uintptr]bool, p uintptr) map[uintptr]bool {
+	if m == nil {
+		m = make(map[uintptr]bool)
+	}
+	m[p] = true
+	return m
+}
+
+// isZero reports whether v is the zero value.
+// This does not rely on Interface and so can be used on unexported fields.
+func isZero(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Bool:
+		return v.Bool() == false
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() == 0
+	case reflect.String:
+		return v.String() == ""
+	case reflect.UnsafePointer:
+		return v.Pointer() == 0
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Ptr, reflect.Map, reflect.Slice:
+		return v.IsNil()
+	case reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if !isZero(v.Index(i)) {
+				return false
+			}
+		}
+		return true
+	case reflect.Struct:
+		for i := 0; i < v.NumField(); i++ {
+			if !isZero(v.Field(i)) {
+				return false
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// isLess is a generic function for sorting arbitrary map keys.
+// The inputs must be of the same type and must be comparable.
+func isLess(x, y reflect.Value) bool {
+	switch x.Type().Kind() {
+	case reflect.Bool:
+		return !x.Bool() && y.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return x.Int() < y.Int()
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return x.Uint() < y.Uint()
+	case reflect.Float32, reflect.Float64:
+		fx, fy := x.Float(), y.Float()
+		return fx < fy || math.IsNaN(fx) && !math.IsNaN(fy)
+	case reflect.Complex64, reflect.Complex128:
+		cx, cy := x.Complex(), y.Complex()
+		rx, ix, ry, iy := real(cx), imag(cx), real(cy), imag(cy)
+		if rx == ry || (math.IsNaN(rx) && math.IsNaN(ry)) {
+			return ix < iy || math.IsNaN(ix) && !math.IsNaN(iy)
+		}
+		return rx < ry || math.IsNaN(rx) && !math.IsNaN(ry)
+	case reflect.Ptr, reflect.UnsafePointer, reflect.Chan:
+		return x.Pointer() < y.Pointer()
+	case reflect.String:
+		return x.String() < y.String()
+	case reflect.Array:
+		for i := 0; i < x.Len(); i++ {
+			if isLess(x.Index(i), y.Index(i)) {
+				return true
+			}
+			if isLess(y.Index(i), x.Index(i)) {
+				return false
+			}
+		}
+		return false
+	case reflect.Struct:
+		for i := 0; i < x.NumField(); i++ {
+			if isLess(x.Field(i), y.Field(i)) {
+				return true
+			}
+			if isLess(y.Field(i), x.Field(i)) {
+				return false
+			}
+		}
+		return false
+	case reflect.Interface:
+		vx, vy := x.Elem(), y.Elem()
+		if !vx.IsValid() || !vy.IsValid() {
+			return !vx.IsValid() && vy.IsValid()
+		}
+		tx, ty := vx.Type(), vy.Type()
+		if tx == ty {
+			return isLess(x.Elem(), y.Elem())
+		}
+		if tx.Kind() != ty.Kind() {
+			return vx.Kind() < vy.Kind()
+		}
+		if tx.String() != ty.String() {
+			return tx.String() < ty.String()
+		}
+		if tx.PkgPath() != ty.PkgPath() {
+			return tx.PkgPath() < ty.PkgPath()
+		}
+		// This can happen in rare situations, so we fallback to just comparing
+		// the unique pointer for a reflect.Type. This guarantees deterministic
+		// ordering within a program, but it is obviously not stable.
+		return reflect.ValueOf(vx.Type()).Pointer() < reflect.ValueOf(vy.Type()).Pointer()
+	default:
+		// Must be Func, Map, or Slice; which are not comparable.
+		panic(fmt.Sprintf("%T is not comparable", x.Type()))
+	}
+}
+
+// sortKey sorts a list of map keys, deduplicating keys if necessary.
+func sortKeys(vs []reflect.Value) []reflect.Value {
+	if len(vs) == 0 {
+		return vs
+	}
+
+	// Sort the map keys.
+	sort.Sort(valueSorter(vs))
+
+	// Deduplicate keys (fails for NaNs).
+	vs2 := vs[:1]
+	for _, v := range vs[1:] {
+		if v.Interface() != vs2[len(vs2)-1].Interface() {
+			vs2 = append(vs2, v)
+		}
+	}
+	return vs2
+}
+
+// TODO: Use sort.Slice once Google AppEngine is on Go1.8 or above.
+type valueSorter []reflect.Value
+
+func (vs valueSorter) Len() int           { return len(vs) }
+func (vs valueSorter) Less(i, j int) bool { return isLess(vs[i], vs[j]) }
+func (vs valueSorter) Swap(i, j int)      { vs[i], vs[j] = vs[j], vs[i] }

--- a/vendor/github.com/google/go-cmp/cmp/reporter_test.go
+++ b/vendor/github.com/google/go-cmp/cmp/reporter_test.go
@@ -1,0 +1,227 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+package cmp
+
+import (
+	"bytes"
+	"io"
+	"math"
+	"reflect"
+	"testing"
+)
+
+func TestFormatAny(t *testing.T) {
+	type key struct {
+		a int
+		b string
+		c chan bool
+	}
+
+	tests := []struct {
+		in   interface{}
+		want string
+	}{{
+		in:   []int{},
+		want: "[]int{}",
+	}, {
+		in:   []int(nil),
+		want: "[]int(nil)",
+	}, {
+		in:   []int{1, 2, 3, 4, 5},
+		want: "[]int{1, 2, 3, 4, 5}",
+	}, {
+		in:   []interface{}{1, true, "hello", struct{ A, B int }{1, 2}},
+		want: "[]interface {}{1, true, \"hello\", struct { A int; B int }{A: 1, B: 2}}",
+	}, {
+		in:   []struct{ A, B int }{{1, 2}, {0, 4}, {}},
+		want: "[]struct { A int; B int }{{A: 1, B: 2}, {B: 4}, {}}",
+	}, {
+		in:   map[*int]string{new(int): "hello"},
+		want: "map[*int]string{0x00: \"hello\"}",
+	}, {
+		in:   map[key]string{{}: "hello"},
+		want: "map[cmp.key]string{{}: \"hello\"}",
+	}, {
+		in:   map[key]string{{a: 5, b: "key", c: make(chan bool)}: "hello"},
+		want: "map[cmp.key]string{{a: 5, b: \"key\", c: (chan bool)(0x00)}: \"hello\"}",
+	}, {
+		in:   map[io.Reader]string{new(bytes.Reader): "hello"},
+		want: "map[io.Reader]string{0x00: \"hello\"}",
+	}, {
+		in: func() interface{} {
+			var a = []interface{}{nil}
+			a[0] = a
+			return a
+		}(),
+		want: "[]interface {}{([]interface {})(0x00)}",
+	}, {
+		in: func() interface{} {
+			type A *A
+			var a A
+			a = &a
+			return a
+		}(),
+		want: "&(cmp.A)(0x00)",
+	}, {
+		in: func() interface{} {
+			type A map[*A]A
+			a := make(A)
+			a[&a] = a
+			return a
+		}(),
+		want: "cmp.A{0x00: 0x00}",
+	}, {
+		in: func() interface{} {
+			var a [2]interface{}
+			a[0] = &a
+			return a
+		}(),
+		want: "[2]interface {}{&[2]interface {}{(*[2]interface {})(0x00), interface {}(nil)}, interface {}(nil)}",
+	}}
+
+	for i, tt := range tests {
+		got := formatAny(reflect.ValueOf(tt.in), formatConfig{true, true, true, false}, nil)
+		if got != tt.want {
+			t.Errorf("test %d, pretty print:\ngot  %q\nwant %q", i, got, tt.want)
+		}
+	}
+}
+
+func TestSortKeys(t *testing.T) {
+	type (
+		MyString string
+		MyArray  [2]int
+		MyStruct struct {
+			A MyString
+			B MyArray
+			C chan float64
+		}
+		EmptyStruct struct{}
+	)
+
+	opts := []Option{
+		Comparer(func(x, y float64) bool {
+			if math.IsNaN(x) && math.IsNaN(y) {
+				return true
+			}
+			return x == y
+		}),
+		Comparer(func(x, y complex128) bool {
+			rx, ix, ry, iy := real(x), imag(x), real(y), imag(y)
+			if math.IsNaN(rx) && math.IsNaN(ry) {
+				rx, ry = 0, 0
+			}
+			if math.IsNaN(ix) && math.IsNaN(iy) {
+				ix, iy = 0, 0
+			}
+			return rx == ry && ix == iy
+		}),
+		Comparer(func(x, y chan bool) bool { return true }),
+		Comparer(func(x, y chan int) bool { return true }),
+		Comparer(func(x, y chan float64) bool { return true }),
+		Comparer(func(x, y chan interface{}) bool { return true }),
+		Comparer(func(x, y *int) bool { return true }),
+	}
+
+	tests := []struct {
+		in   map[interface{}]bool // Set of keys to sort
+		want []interface{}
+	}{{
+		in:   map[interface{}]bool{1: true, 2: true, 3: true},
+		want: []interface{}{1, 2, 3},
+	}, {
+		in: map[interface{}]bool{
+			nil:                    true,
+			true:                   true,
+			false:                  true,
+			-5:                     true,
+			-55:                    true,
+			-555:                   true,
+			uint(1):                true,
+			uint(11):               true,
+			uint(111):              true,
+			"abc":                  true,
+			"abcd":                 true,
+			"abcde":                true,
+			"foo":                  true,
+			"bar":                  true,
+			MyString("abc"):        true,
+			MyString("abcd"):       true,
+			MyString("abcde"):      true,
+			new(int):               true,
+			new(int):               true,
+			make(chan bool):        true,
+			make(chan bool):        true,
+			make(chan int):         true,
+			make(chan interface{}): true,
+			math.Inf(+1):           true,
+			math.Inf(-1):           true,
+			1.2345:                 true,
+			12.345:                 true,
+			123.45:                 true,
+			1234.5:                 true,
+			0 + 0i:                 true,
+			1 + 0i:                 true,
+			2 + 0i:                 true,
+			0 + 1i:                 true,
+			0 + 2i:                 true,
+			0 + 3i:                 true,
+			[2]int{2, 3}:           true,
+			[2]int{4, 0}:           true,
+			[2]int{2, 4}:           true,
+			MyArray([2]int{2, 4}):  true,
+			EmptyStruct{}:          true,
+			MyStruct{
+				"bravo", [2]int{2, 3}, make(chan float64),
+			}: true,
+			MyStruct{
+				"alpha", [2]int{3, 3}, make(chan float64),
+			}: true,
+		},
+		want: []interface{}{
+			nil, false, true,
+			-555, -55, -5, uint(1), uint(11), uint(111),
+			math.Inf(-1), 1.2345, 12.345, 123.45, 1234.5, math.Inf(+1),
+			(0 + 0i), (0 + 1i), (0 + 2i), (0 + 3i), (1 + 0i), (2 + 0i),
+			[2]int{2, 3}, [2]int{2, 4}, [2]int{4, 0}, MyArray([2]int{2, 4}),
+			make(chan bool), make(chan bool), make(chan int), make(chan interface{}),
+			new(int), new(int),
+			MyString("abc"), MyString("abcd"), MyString("abcde"), "abc", "abcd", "abcde", "bar", "foo",
+			EmptyStruct{},
+			MyStruct{"alpha", [2]int{3, 3}, make(chan float64)},
+			MyStruct{"bravo", [2]int{2, 3}, make(chan float64)},
+		},
+	}, {
+		// NaN values cannot be properly deduplicated.
+		// This is okay since map entries with NaN in the keys cannot be
+		// retrieved anyways.
+		in: map[interface{}]bool{
+			math.NaN():                      true,
+			math.NaN():                      true,
+			complex(0, math.NaN()):          true,
+			complex(0, math.NaN()):          true,
+			complex(math.NaN(), 0):          true,
+			complex(math.NaN(), 0):          true,
+			complex(math.NaN(), math.NaN()): true,
+		},
+		want: []interface{}{
+			math.NaN(), math.NaN(), math.NaN(), math.NaN(),
+			complex(math.NaN(), math.NaN()), complex(math.NaN(), math.NaN()),
+			complex(math.NaN(), 0), complex(math.NaN(), 0), complex(math.NaN(), 0), complex(math.NaN(), 0),
+			complex(0, math.NaN()), complex(0, math.NaN()), complex(0, math.NaN()), complex(0, math.NaN()),
+		},
+	}}
+
+	for i, tt := range tests {
+		keys := append(reflect.ValueOf(tt.in).MapKeys(), reflect.ValueOf(tt.in).MapKeys()...)
+		var got []interface{}
+		for _, k := range sortKeys(keys) {
+			got = append(got, k.Interface())
+		}
+		if !Equal(got, tt.want, opts...) {
+			t.Errorf("test %d, output mismatch:\ngot  %#v\nwant %#v", i, got, tt.want)
+		}
+	}
+}

--- a/vendor/github.com/google/go-cmp/cmp/unsafe_panic.go
+++ b/vendor/github.com/google/go-cmp/cmp/unsafe_panic.go
@@ -1,0 +1,15 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build appengine js
+
+package cmp
+
+import "reflect"
+
+const supportAllowUnexported = false
+
+func unsafeRetrieveField(reflect.Value, reflect.StructField) reflect.Value {
+	panic("unsafeRetrieveField is not implemented")
+}

--- a/vendor/github.com/google/go-cmp/cmp/unsafe_reflect.go
+++ b/vendor/github.com/google/go-cmp/cmp/unsafe_reflect.go
@@ -1,0 +1,23 @@
+// Copyright 2017, The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE.md file.
+
+// +build !appengine,!js
+
+package cmp
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+const supportAllowUnexported = true
+
+// unsafeRetrieveField uses unsafe to forcibly retrieve any field from a struct
+// such that the value has read-write permissions.
+//
+// The parent struct, v, must be addressable, while f must be a StructField
+// describing the field to retrieve.
+func unsafeRetrieveField(v reflect.Value, f reflect.StructField) reflect.Value {
+	return reflect.NewAt(f.Type, unsafe.Pointer(v.UnsafeAddr()+f.Offset)).Elem()
+}


### PR DESCRIPTION
This add a bunch of timeout configuration options. The most notable are ``GCS_HELPER_PROXY_TIMEOUT`` and ``GCS_CLIENT_TIMEOUT``. The former is a global timeout on proxy operations and the latter is a timeout on ``gcs-helper -> gcp api`` operations. Since the GCS library automatically retries on errors, ``max_retries = ~(GCS_HELPER_PROXY_TIMEOUT / GCS_CLIENT_TIMEOUT)``.

I also included some documentation for the values on the README. Feedback on everything (including variable names) is very welcome :)