### PR TITLE
Add option on map mode to support looking for files in different places

### DIFF
--- a/config.go
+++ b/config.go
@@ -11,15 +11,16 @@ import (
 // Config represents the gcs-helper configuration that is loaded from the
 // environment.
 type Config struct {
-	Listen          string        `default:":8080"`
-	BucketName      string        `envconfig:"BUCKET_NAME" required:"true"`
-	LogLevel        string        `envconfig:"LOG_LEVEL" default:"debug"`
-	ProxyLogHeaders []string      `envconfig:"PROXY_LOG_HEADERS"`
-	ProxyPrefix     string        `envconfig:"PROXY_PREFIX"`
-	ProxyTimeout    time.Duration `envconfig:"PROXY_TIMEOUT" default:"10s"`
-	MapPrefix       string        `envconfig:"MAP_PREFIX"`
-	MapExtensions   []string      `envconfig:"MAP_EXTENSIONS"`
-	ClientConfig    ClientConfig
+	Listen           string        `default:":8080"`
+	BucketName       string        `envconfig:"BUCKET_NAME" required:"true"`
+	LogLevel         string        `envconfig:"LOG_LEVEL" default:"debug"`
+	ProxyLogHeaders  []string      `envconfig:"PROXY_LOG_HEADERS"`
+	ProxyPrefix      string        `envconfig:"PROXY_PREFIX"`
+	ProxyTimeout     time.Duration `envconfig:"PROXY_TIMEOUT" default:"10s"`
+	MapPrefix        string        `envconfig:"MAP_PREFIX"`
+	MapExtensions    []string      `envconfig:"MAP_EXTENSIONS"`
+	MapExtraPrefixes []string      `envconfig:"MAP_EXTRA_PREFIXES"`
+	ClientConfig     ClientConfig
 }
 
 // ClientConfig contains configuration for the GCS client communication.

--- a/config_test.go
+++ b/config_test.go
@@ -11,31 +11,33 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	setEnvs(map[string]string{
-		"GCS_HELPER_LISTEN":            "0.0.0.0:3030",
-		"GCS_HELPER_BUCKET_NAME":       "some-bucket",
-		"GCS_HELPER_LOG_LEVEL":         "info",
-		"GCS_HELPER_MAP_PREFIX":        "/map/",
-		"GCS_HELPER_PROXY_PREFIX":      "/proxy/",
-		"GCS_HELPER_PROXY_LOG_HEADERS": "Accept,Range",
-		"GCS_HELPER_PROXY_TIMEOUT":     "20s",
-		"GCS_HELPER_MAP_EXTENSIONS":    ".mp4,.vtt,.srt",
-		"GCS_CLIENT_TIMEOUT":           "60s",
-		"GCS_CLIENT_IDLE_CONN_TIMEOUT": "3m",
-		"GCS_CLIENT_MAX_IDLE_CONNS":    "16",
+		"GCS_HELPER_LISTEN":             "0.0.0.0:3030",
+		"GCS_HELPER_BUCKET_NAME":        "some-bucket",
+		"GCS_HELPER_LOG_LEVEL":          "info",
+		"GCS_HELPER_MAP_PREFIX":         "/map/",
+		"GCS_HELPER_PROXY_PREFIX":       "/proxy/",
+		"GCS_HELPER_PROXY_LOG_HEADERS":  "Accept,Range",
+		"GCS_HELPER_PROXY_TIMEOUT":      "20s",
+		"GCS_HELPER_MAP_EXTENSIONS":     ".mp4,.vtt,.srt",
+		"GCS_HELPER_MAP_EXTRA_PREFIXES": "subtitles/,mp4s/",
+		"GCS_CLIENT_TIMEOUT":            "60s",
+		"GCS_CLIENT_IDLE_CONN_TIMEOUT":  "3m",
+		"GCS_CLIENT_MAX_IDLE_CONNS":     "16",
 	})
 	config, err := loadConfig()
 	if err != nil {
 		t.Fatal(err)
 	}
 	expectedConfig := Config{
-		BucketName:      "some-bucket",
-		Listen:          "0.0.0.0:3030",
-		LogLevel:        "info",
-		MapPrefix:       "/map/",
-		ProxyPrefix:     "/proxy/",
-		MapExtensions:   []string{".mp4", ".vtt", ".srt"},
-		ProxyLogHeaders: []string{"Accept", "Range"},
-		ProxyTimeout:    20 * time.Second,
+		BucketName:       "some-bucket",
+		Listen:           "0.0.0.0:3030",
+		LogLevel:         "info",
+		MapPrefix:        "/map/",
+		ProxyPrefix:      "/proxy/",
+		MapExtensions:    []string{".mp4", ".vtt", ".srt"},
+		MapExtraPrefixes: []string{"subtitles/", "mp4s/"},
+		ProxyLogHeaders:  []string{"Accept", "Range"},
+		ProxyTimeout:     20 * time.Second,
 		ClientConfig: ClientConfig{
 			IdleConnTimeout: 3 * time.Minute,
 			MaxIdleConns:    16,

--- a/server_test.go
+++ b/server_test.go
@@ -14,11 +14,12 @@ import (
 
 func TestServerMultiPrefixes(t *testing.T) {
 	addr, cleanup := startServer(t, Config{
-		BucketName:    "my-bucket",
-		MapPrefix:     "/map/",
-		ProxyPrefix:   "/proxy/",
-		ProxyTimeout:  time.Second,
-		MapExtensions: []string{".mp3", ".txt"},
+		BucketName:       "my-bucket",
+		MapPrefix:        "/map/",
+		MapExtraPrefixes: []string{"subs/", "mp4s/"},
+		ProxyPrefix:      "/proxy/",
+		ProxyTimeout:     time.Second,
+		MapExtensions:    []string{".mp3", ".txt", ".mp4", ".srt"},
 	})
 	defer cleanup()
 	var tests = []serverTest{
@@ -98,6 +99,41 @@ func TestServerMultiPrefixes(t *testing.T) {
 							map[string]interface{}{
 								"type": "source",
 								"path": "/musics/music/music4.mp3",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			testCase:       "map: list of files including extra prefixes",
+			method:         http.MethodGet,
+			addr:           addr + "/map/videos/video/video1",
+			expectedStatus: http.StatusOK,
+			expectedHeader: http.Header{"Content-Type": []string{"application/json"}},
+			expectedBody: map[string]interface{}{
+				"sequences": []interface{}{
+					map[string]interface{}{
+						"clips": []interface{}{
+							map[string]interface{}{
+								"type": "source",
+								"path": "/videos/video/video1_480p.mp4",
+							},
+						},
+					},
+					map[string]interface{}{
+						"clips": []interface{}{
+							map[string]interface{}{
+								"type": "source",
+								"path": "/videos/video/video1_720p.mp4",
+							},
+						},
+					},
+					map[string]interface{}{
+						"clips": []interface{}{
+							map[string]interface{}{
+								"type": "source",
+								"path": "/subs/video1.srt",
 							},
 						},
 					},
@@ -237,6 +273,18 @@ func getObjects() []fakestorage.Object {
 		{
 			BucketName: "my-bucket",
 			Name:       "musics/musics/music1.txt",
+		},
+		{
+			BucketName: "my-bucket",
+			Name:       "videos/video/video1_720p.mp4",
+		},
+		{
+			BucketName: "my-bucket",
+			Name:       "videos/video/video1_480p.mp4",
+		},
+		{
+			BucketName: "my-bucket",
+			Name:       "subs/video1.srt",
 		},
 		{
 			BucketName: "your-bucket",


### PR DESCRIPTION
The GCS_HELPER_MAP_EXTRA_PREFIXES option will provide a list of extra
folders where gcs-helper should look for files when running in mapped
mode.

The main goal of this change is to be able to support video files and
caption files in different "folders". This can also be expanded to
change the way video files are organized.